### PR TITLE
Use non deprecated method

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -140,7 +140,7 @@ class Configuration implements ConfigurationInterface
         }
 
         $client = new \Google_Client();
-        $client->setAuthConfigFile($this->authConfigFilePath);
+        $client->setAuthConfig($this->authConfigFilePath);
         $client->addScope([
             'https://www.googleapis.com/auth/userinfo.email',
             'https://www.googleapis.com/auth/firebase.database'


### PR DESCRIPTION
Hi, I have one point to fix.

`Google_Client::setAuthConfigFile` is deprecated now. So I replace this method.
https://github.com/google/google-api-php-client/blob/master/src/Google/Client.php#L830

Actually I want to use latest version of your library, but my PHP version is not 7~.
So please consider about this PR.

Thank you :)