### PR TITLE
Add Authentication and User Management features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Unreleased
+
+* Added user management features ([Documentation](https://firebase-php.readthedocs.io/en/latest/user-management.html))
+* Deprecated `Kreait\Firebase\Factory::withServiceAccount()`, use `Kreait\Firebase\Factory::withServiceAccountAndApiKey()` instead 
+* Deprecated `Kreait\Firebase::asUserWithClaims()`, use `Kreait\Firebase\Auth::getUser()` and `Kreait\Firebase::asUser()` instead
+* Deprecated `Kreait\Firebase::getTokenHandler()`, use `Kreait\Firebase\Auth::createCustomToken()` and `Kreait\Firebase\Auth::verifyIdToken()` instead.
+* Added migration instructions for deprecated methods, see [Documentation](https://firebase-php.readthedocs.io/en/latest/migration.html#to-3-2)
+  
 ## 3.1.2 - 2017-08-11
 
 * Removed the restriction to the google/auth package to versions <1.0

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -11,17 +11,25 @@ a user id as the first parameter, and an optional array with claims as the secon
 
 .. code-block:: php
 
-    use Kreait\Firebase;
+    use Kreait\Firebase\Factory;
+    use Kreait\Firebase\ServiceAccount;
 
-    $firebase = (new Firebase\Factory())->create();
+    $serviceAccount = ServiceAccount::fromJsonFile(__DIR__.'/google-service-account.json');
+    $apiKey = '<Firebase Web API key>';
 
-    $authenticated = $firebase->asUserWithClaims('a-user-id', [
-        'premium-user' => true
-    ]);
+    $firebase = (new Factory)
+        ->withServiceAccountAndApiKey($serviceAccount, $apiKey)
+        ->create();
 
-*******************
-Working with Tokens
-*******************
+    $user = $firebase->getAuth()->getUser('a-user-id');
+    // You can also set claims for the given user
+    $user = $firebase->getAuth()->getUser('a-user-id', ['premium-user' => true]);
+
+    $authenticated = $firebase->asUser($user);
+
+****************************
+Working with Tokens directly
+****************************
 
 If you need to create `Custom Tokens <https://firebase.google.com/docs/auth/server/create-custom-tokens>`_
 or verify `ID Tokens <https://firebase.google.com/docs/auth/admin/verify-id-tokens>`_, a Service Account
@@ -33,34 +41,22 @@ based Firebase instance provides the ``getTokenHandler()`` method:
 
     $firebase = (new Firebase\Factory())->create();
 
-    $tokenHandler = $firebase->getTokenHandler();
+    $auth = $firebase->getAuth();
 
     $uid = 'a-uid';
     $claims = ['foo' => 'bar']; // optional
 
     // Returns a Lcobucci\JWT\Token instance
-    $customToken = $tokenHandler->createCustomToken($uid, $claims);
+    $customToken = $auth->createCustomToken($uid, $claims);
     echo $customToken; // "eyJ0eXAiOiJKV1..."
 
     $idTokenString = 'eyJhbGciOiJSUzI1...';
     // Returns a Lcobucci\JWT\Token instance
-    $idToken = $tokenHandler->verifyIdToken($idTokenString);
+    $idToken = $auth->verifyIdToken($idTokenString);
 
     $uid = $idToken->getClaim('sub');
 
     echo $uid; // 'a-uid'
-
-If you want to use a custom token handler, you can do so by passing it to the factory:
-
-.. code-block:: php
-
-    use Kreait\Firebase;
-
-    $handler = new Firebase\Auth\Token\Handler(...);
-
-    $firebase = (new Firebase\Factory())
-        ->withTokenHandler($handler);
-        ->create();
 
 .. note::
     A standalone version of the Token Handler is available with the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,9 +18,10 @@ The source code can be found at https://github.com/kreait/firebase-php/
     use Kreait\Firebase\ServiceAccount;
 
     $serviceAccount = ServiceAccount::fromJsonFile(__DIR__.'/google-service-account.json');
+    $apiKey = '<Firebase Web API key>';
 
     $firebase = (new Factory)
-        ->withServiceAccount($serviceAccount)
+        ->withServiceAccountAndApiKey($serviceAccount, $apiKey)
         ->withDatabaseUri('https://my-project.firebaseio.com')
         ->create();
 
@@ -52,6 +53,7 @@ User Guide
     setup
     realtime-database
     authentication
+    user-management
     troubleshooting
     migration
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -3,6 +3,65 @@ Migration
 #########
 
 **********
+3.1 to 3.2
+**********
+
+.. rubric:: Kreait\Firebase::asUserWithClaims() has been deprecated
+
+Use ``Kreait\Firebase\Auth::getUser()`` and ``Kreait\Firebase::asUser()`` instead.
+
+.. code-block:: php
+
+    # Before
+    $authenticated = $firebase->asUserWithClaims('a-uid', ['claim' => 'value']);
+
+    # After
+    $user = $firebase->getAuth()->getUser('a-uid', ['claim' => 'value]);
+    $authenticated = $firebase->asUser($user);
+
+.. rubric:: Kreait\Firebase\Factory::withServiceAccount() has been deprecated
+
+Use ``Kreait\Firebase\Factory::withServiceAccountAndApiKey()`` instead.
+
+.. code-block:: php
+
+    # Before
+    use Kreait\Firebase\Factory;
+    use Kreait\Firebase\ServiceAccount;
+
+    $serviceAccount = ServiceAccount::fromJsonFile(__DIR__.'/google-service-account.json');
+    $firebase = (new Firebase\Factory)
+        ->withServiceAccount($serviceAccount);
+
+    # After
+    use Kreait\Firebase\Factory;
+    use Kreait\Firebase\ServiceAccount;
+
+    $serviceAccount = ServiceAccount::fromJsonFile(__DIR__.'/google-service-account.json');
+    $apiKey = '<Firebase Web API key>';
+
+    $firebase = (new Factory)
+        ->withServiceAccountAndApiKey($serviceAccount, $apiKey)
+        ->withDatabaseUri('https://my-project.firebaseio.com')
+        ->create();
+
+.. rubric:: Kreait\Firebase::getTokenHandler() has been deprecated
+
+Use ``Kreait\Firebase\Auth::createCustomToken()`` and ``Kreait\Firebase\Auth::verifyIdToken()`` instead.
+
+.. code-block:: php
+
+    # Before
+    $tokenHandler = $firebase->getTokenHandler();
+    $tokenHandler->createCustomToken(...);
+    $tokenHandler->verifyIdToken(...);
+
+    # After
+    $auth = $firebase->getAuth();
+    $auth->createCustomToken(...);
+    $auth->verifyIdToken(...);
+
+**********
 3.0 to 3.1
 **********
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -104,3 +104,23 @@ be explicit, you can configure the Factory like this:
     $firebase = (new Factory)
         ->withDatabaseUri('https://my-project.firebaseio.com')
         ->create();
+
+
+******************************
+Enable user management fetures
+******************************
+
+To be able to use user management features, you have to provide the Firebase Web API key
+to the factory. You can find the key in the settings area of your Firebase project.
+
+.. code-block:: php
+
+    use Kreait\Firebase\Factory;
+    use Kreait\Firebase\ServiceAccount;
+
+    $serviceAccount = ServiceAccount::fromJsonFile(__DIR__.'/google-service-account.json');
+    $apiKey = '<Firebase Web API key>';
+
+    $firebase = (new Factory)
+        ->withServiceAccountAndApiKey($serviceAccount, $apiKey)
+        ->create();

--- a/docs/user-management.rst
+++ b/docs/user-management.rst
@@ -19,6 +19,23 @@ to the Firebase factory and getting an ``Auth`` instance:
 
     $auth = $firebase->getAuth();
 
+
+**************************
+Creating an anonymous user
+**************************
+
+.. code-block:: php
+
+    $user = $auth->createAnonymousUser();
+
+***************************************
+Creating a user with email and password
+***************************************
+
+.. code-block:: php
+
+    $user = $auth->createUserWithEmailAndPassword('user@domain.tld', 'a secure password');
+
 *********************
 Getting a user by UID
 *********************
@@ -28,6 +45,14 @@ Getting a user by UID
     $user = $auth->getUser('some-uid');
     # Setting additional claims for the user
     $user = $auth->getUser('some-uid', ['premium-user' => true]);
+
+************************************
+Getting a user by email and password
+************************************
+
+.. code-block:: php
+
+    $user = $auth->getUserByEmailAndPassword('user@domain.tld', 'a password');
 
 **************************
 Changing a user's password
@@ -55,22 +80,6 @@ Deleting a user
 
     $user = $auth->getUser('some-uid');
     $auth->deleteUser($user);
-
-**************************
-Creating an anonymous user
-**************************
-
-.. code-block:: php
-
-    $user = $auth->createAnonymousUser();
-
-***************************************
-Creating a user with email and password
-***************************************
-
-.. code-block:: php
-
-    $user = $auth->createUserWithEmailAndPassword('user@domain.tld', 'a secure password');
 
 *************************************
 Trigger email verification for a user

--- a/docs/user-management.rst
+++ b/docs/user-management.rst
@@ -1,0 +1,83 @@
+###############
+User management
+###############
+
+You can enable user management features by providing your project's web API key
+to the Firebase factory and getting an ``Auth`` instance:
+
+.. code-block:: php
+
+    use Kreait\Firebase\Factory;
+    use Kreait\Firebase\ServiceAccount;
+
+    $serviceAccount = ServiceAccount::fromJsonFile(__DIR__.'/google-service-account.json');
+    $apiKey = '<Firebase Web API key>';
+
+    $firebase = (new Factory)
+        ->withServiceAccountAndApiKey($serviceAccount, $apiKey)
+        ->create();
+
+    $auth = $firebase->getAuth();
+
+*********************
+Getting a user by UID
+*********************
+
+.. code-block:: php
+
+    $user = $auth->getUser('some-uid');
+    # Setting additional claims for the user
+    $user = $auth->getUser('some-uid', ['premium-user' => true]);
+
+**************************
+Changing a user's password
+**************************
+
+.. code-block:: php
+
+    $user = $auth->getUser('some-uid');
+    $updatedUser = $auth->changeUserPassword($user, 'new password');
+
+***********************
+Changing a user's email
+***********************
+
+.. code-block:: php
+
+    $user = $auth->getUser('some-uid');
+    $updatedUser = $auth->changeUserEmail($user, 'user@domain.tld');
+
+***************
+Deleting a user
+***************
+
+.. code-block:: php
+
+    $user = $auth->getUser('some-uid');
+    $auth->deleteUser($user);
+
+**************************
+Creating an anonymous user
+**************************
+
+.. code-block:: php
+
+    $user = $auth->createAnonymousUser();
+
+***************************************
+Creating a user with email and password
+***************************************
+
+.. code-block:: php
+
+    $user = $auth->createUserWithEmailAndPassword('user@domain.tld', 'a secure password');
+
+*************************************
+Trigger email verification for a user
+*************************************
+
+.. code-block:: php
+
+    $user = $auth->getUser('some-uid');
+    $auth->sendEmailVerification($user);
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src/Firebase</directory>
+            <file>src/Firebase.php</file>
         </whitelist>
     </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.0/phpunit.xsd"
     beStrictAboutOutputDuringTests="true"
+    bootstrap="tests/bootstrap.php"
     colors="true">
     <testsuites>
         <testsuite name="Firebase Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
     colors="true">
     <testsuites>
         <testsuite name="Firebase Test Suite">
-            <directory suffix="Test.php">tests</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -104,6 +104,8 @@ class Firebase
      * Returns a new instance with the permissions
      * of the user with the given UID and claims.
      *
+     * @deprecated 3.2 use {@see \Kreait\Firebase\Auth::getUser()} and {@see \Kreait\Firebase::asUser()} instead
+     *
      * @param string|User $user
      * @param array $claims
      *
@@ -135,7 +137,7 @@ class Firebase
     }
 
     /**
-     * @deprecated 3.2 use {@see \Firebase\Auth::createCustomToken()} or {@see \Firebase\Auth::verifyIdToken()} instead
+     * @deprecated 3.2 use {@see \Kreait\Firebase\Auth::createCustomToken()} or {@see \Kreait\Firebase\Auth::verifyIdToken()} instead
      */
     public function getTokenHandler(): TokenHandler
     {

--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -102,7 +102,7 @@ class Firebase
     private function withCustomAuth(Auth $override): Firebase
     {
         $firebase = new self($this->serviceAccount, $this->databaseUri, $this->tokenHandler);
-        $firebase->database = $this->getDatabase()->withCustomAuth($override);
+        $firebase->database = $this->createDatabase()->withCustomAuth($override);
 
         return $firebase;
     }

--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -119,7 +119,8 @@ class Firebase
     {
         trigger_error(
             'The token handler is deprecated and will be removed in release 4.0 of this library.'
-            .' Use Firebase\Auth::createCustomToken() instead.', E_USER_DEPRECATED
+            .' Use Firebase\Auth::createCustomToken() or Firebase\Auth::verifyIdToken() instead.',
+            E_USER_DEPRECATED
         );
 
         return $this->tokenHandler;

--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -113,7 +113,7 @@ class Firebase
     }
 
     /**
-     * @deprecated 3.2 use {@see \Firebase\Auth::createCustomToken()} instead
+     * @deprecated 3.2 use {@see \Firebase\Auth::createCustomToken()} or {@see \Firebase\Auth::verifyIdToken()} instead
      */
     public function getTokenHandler(): TokenHandler
     {

--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -10,6 +10,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
 use Kreait\Firebase\Database;
 use Kreait\Firebase\Database\ApiClient;
+use Kreait\Firebase\Exception\LogicException;
 use Kreait\Firebase\Http\Auth;
 use Kreait\Firebase\Http\Auth\CustomToken;
 use Kreait\Firebase\Http\Middleware;
@@ -38,11 +39,21 @@ class Firebase
      */
     private $tokenHandler;
 
-    public function __construct(ServiceAccount $serviceAccount, UriInterface $databaseUri, TokenHandler $tokenHandler)
-    {
+    /**
+     * @var Firebase\Auth|null
+     */
+    private $auth;
+
+    public function __construct(
+        ServiceAccount $serviceAccount,
+        UriInterface $databaseUri,
+        TokenHandler $tokenHandler,
+        Firebase\Auth $auth = null
+    ) {
         $this->serviceAccount = $serviceAccount;
         $this->databaseUri = $databaseUri;
         $this->tokenHandler = $tokenHandler;
+        $this->auth = $auth;
     }
 
     /**
@@ -72,6 +83,22 @@ class Firebase
     }
 
     /**
+     * Returns an Auth instance.
+     *
+     * @throws \Kreait\Firebase\Exception\LogicException
+     *
+     * @return Firebase\Auth
+     */
+    public function getAuth(): Firebase\Auth
+    {
+        if (!$this->auth) {
+            throw new LogicException('You need to configure Firebase with an API key via the factory to use the Authentication capabilities.');
+        }
+
+        return $this->auth;
+    }
+
+    /**
      * Returns a new instance with the permissions
      * of the user with the given UID and claims.
      *
@@ -86,16 +113,15 @@ class Firebase
     }
 
     /**
-     * Returns a Token Handler to be used for creating Custom Tokens and
-     * verifying ID tokens.
-     *
-     * @see https://firebase.google.com/docs/auth/admin/create-custom-tokens
-     * @see https://firebase.google.com/docs/auth/admin/verify-id-tokens
-     *
-     * @return TokenHandler
+     * @deprecated 3.2 use {@see \Firebase\Auth::createCustomToken()} instead
      */
     public function getTokenHandler(): TokenHandler
     {
+        trigger_error(
+            'The token handler is deprecated and will be removed in release 4.0 of this library.'
+            .' Use Firebase\Auth::createCustomToken() instead.', E_USER_DEPRECATED
+        );
+
         return $this->tokenHandler;
     }
 

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Kreait\Firebase;
+
+use Kreait\Firebase\Auth\ApiClient;
+use Kreait\Firebase\Auth\CustomTokenGenerator;
+use Kreait\Firebase\Auth\User;
+use Kreait\Firebase\Util\JSON;
+use Lcobucci\JWT\Token;
+use Psr\Http\Message\ResponseInterface;
+
+class Auth
+{
+    /**
+     * @var ApiClient
+     */
+    private $client;
+
+    /**
+     * @var CustomTokenGenerator
+     */
+    private $customToken;
+
+    public function __construct(ApiClient $client, CustomTokenGenerator $customToken)
+    {
+        $this->client = $client;
+        $this->customToken = $customToken;
+    }
+
+    public function getApiClient(): ApiClient
+    {
+        return $this->client;
+    }
+
+    public function getUser($uid): User
+    {
+        $response = $this->client->exchangeCustomTokenForIdAndRefreshToken(
+            $this->createCustomToken($uid)
+        );
+
+        return $this->convertResponseToUser($response);
+    }
+
+    public function createUserWithEmailAndPassword(string $email, string $password): User
+    {
+        $response = $this->client->signupNewUser($email, $password);
+
+        return $this->convertResponseToUser($response);
+    }
+
+    public function createAnonymousUser(): User
+    {
+        return $this->createUserWithEmailAndPassword('', '');
+    }
+
+    public function changeUserPassword(User $user, string $newPassword): User
+    {
+        $response = $this->client->changeUserPassword($user, $newPassword);
+
+        return $this->convertResponseToUser($response);
+    }
+
+    public function changeUserEmail(User $user, string $newEmail): User
+    {
+        $response = $this->client->changeUserEmail($user, $newEmail);
+
+        return $this->convertResponseToUser($response);
+    }
+
+    public function deleteUser(User $user): void
+    {
+        $this->client->deleteUser($user);
+    }
+
+    public function sendEmailVerification(User $user): void
+    {
+        $this->client->sendEmailVerification($user);
+    }
+
+    public function createCustomToken($uid, array $claims = [], \DateTimeInterface $expiresAt = null): Token
+    {
+        return $this->customToken->create($uid, $claims, $expiresAt);
+    }
+
+    private function convertResponseToUser(ResponseInterface $response): User
+    {
+        $data = JSON::decode((string) $response->getBody(), true);
+
+        return User::create($data['idToken'], $data['refreshToken']);
+    }
+}

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -55,6 +55,13 @@ class Auth
         return $this->convertResponseToUser($response);
     }
 
+    public function getUserByEmailAndPassword(string $email, string $password): User
+    {
+        $response = $this->client->getUserByEmailAndPassword($email, $password);
+
+        return $this->convertResponseToUser($response);
+    }
+
     public function createAnonymousUser(): User
     {
         return $this->createUserWithEmailAndPassword('', '');

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -4,6 +4,7 @@ namespace Kreait\Firebase;
 
 use Kreait\Firebase\Auth\ApiClient;
 use Kreait\Firebase\Auth\CustomTokenGenerator;
+use Kreait\Firebase\Auth\IdTokenVerifier;
 use Kreait\Firebase\Auth\User;
 use Kreait\Firebase\Util\JSON;
 use Lcobucci\JWT\Token;
@@ -21,10 +22,16 @@ class Auth
      */
     private $customToken;
 
-    public function __construct(ApiClient $client, CustomTokenGenerator $customToken)
+    /**
+     * @var IdTokenVerifier
+     */
+    private $idTokenVerifier;
+
+    public function __construct(ApiClient $client, CustomTokenGenerator $customToken, IdTokenVerifier $idTokenVerifier)
     {
         $this->client = $client;
         $this->customToken = $customToken;
+        $this->idTokenVerifier = $idTokenVerifier;
     }
 
     public function getApiClient(): ApiClient
@@ -80,6 +87,11 @@ class Auth
     public function createCustomToken($uid, array $claims = [], \DateTimeInterface $expiresAt = null): Token
     {
         return $this->customToken->create($uid, $claims, $expiresAt);
+    }
+
+    public function verifyIdToken($idToken): Token
+    {
+        return $this->idTokenVerifier->verify($idToken);
     }
 
     private function convertResponseToUser(ResponseInterface $response): User

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -39,10 +39,10 @@ class Auth
         return $this->client;
     }
 
-    public function getUser($uid): User
+    public function getUser($uid, array $claims = []): User
     {
         $response = $this->client->exchangeCustomTokenForIdAndRefreshToken(
-            $this->createCustomToken($uid)
+            $this->createCustomToken($uid, $claims)
         );
 
         return $this->convertResponseToUser($response);

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Kreait\Firebase\Auth;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use Kreait\Firebase\Exception\Auth\CredentialsMismatch;
+use Kreait\Firebase\Exception\Auth\InvalidCustomToken;
+use Kreait\Firebase\Exception\AuthException;
+use Lcobucci\JWT\Token;
+use Psr\Http\Message\ResponseInterface;
+
+class ApiClient
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Takes a custom token and exchanges it with an ID token.
+     *
+     * @param Token $token
+     *
+     * @see https://firebase.google.com/docs/reference/rest/auth/#section-verify-custom-token
+     *
+     * @throws InvalidCustomToken
+     * @throws CredentialsMismatch
+     *
+     * @return ResponseInterface
+     */
+    public function exchangeCustomTokenForIdAndRefreshToken(Token $token): ResponseInterface
+    {
+        return $this->request('verifyCustomToken', [
+            'token' => (string) $token,
+            'returnSecureToken' => true,
+        ]);
+    }
+
+    /**
+     * Creates a new user with the given email address and password.
+     *
+     * @param string $email
+     * @param string $password
+     *
+     * @see https://firebase.google.com/docs/reference/rest/auth/#section-create-email-password
+     *
+     * @return ResponseInterface
+     */
+    public function signupNewUser(string $email = null, string $password = null): ResponseInterface
+    {
+        return $this->request('signupNewUser', array_filter([
+            'email' => $email,
+            'password' => $password,
+            'returnSecureToken' => true,
+        ]));
+    }
+
+    public function deleteUser(User $user): ResponseInterface
+    {
+        return $this->request('deleteAccount', [
+            'idToken' => (string) $user->getIdToken(),
+        ]);
+    }
+
+    public function changeUserPassword(User $user, string $newPassword): ResponseInterface
+    {
+        return $this->request('setAccountInfo', [
+            'idToken' => (string) $user->getIdToken(),
+            'password' => $newPassword,
+            'returnSecureToken' => true,
+        ]);
+    }
+
+    public function changeUserEmail(User $user, string $newEmail): ResponseInterface
+    {
+        return $this->request('setAccountInfo', [
+            'idToken' => (string) $user->getIdToken(),
+            'email' => $newEmail,
+            'returnSecureToken' => true,
+        ]);
+    }
+
+    public function sendEmailVerification(User $user): ResponseInterface
+    {
+        return $this->request('getOobConfirmationCode', [
+            'requestType' => 'VERIFY_EMAIL',
+            'idToken' => (string) $user->getIdToken(),
+        ]);
+    }
+
+    private function request(string $uri, array $data): ResponseInterface
+    {
+        try {
+            return $this->client->request(RequestMethod::METHOD_POST, $uri, ['json' => $data]);
+        } catch (RequestException $e) {
+            throw AuthException::fromRequestException($e);
+        }
+    }
+}

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -6,7 +6,10 @@ use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use Kreait\Firebase\Exception\Auth\CredentialsMismatch;
+use Kreait\Firebase\Exception\Auth\EmailNotFound;
 use Kreait\Firebase\Exception\Auth\InvalidCustomToken;
+use Kreait\Firebase\Exception\Auth\InvalidPassword;
+use Kreait\Firebase\Exception\Auth\UserDisabled;
 use Kreait\Firebase\Exception\AuthException;
 use Lcobucci\JWT\Token;
 use Psr\Http\Message\ResponseInterface;
@@ -56,6 +59,29 @@ class ApiClient
     public function signupNewUser(string $email = null, string $password = null): ResponseInterface
     {
         return $this->request('signupNewUser', array_filter([
+            'email' => $email,
+            'password' => $password,
+            'returnSecureToken' => true,
+        ]));
+    }
+
+    /**
+     * Returns a user for the given email address and password.
+     *
+     * @param string $email
+     * @param string $password
+     *
+     * @see https://firebase.google.com/docs/reference/rest/auth/#section-sign-in-email-password
+     *
+     * @throws EmailNotFound
+     * @throws InvalidPassword
+     * @throws UserDisabled
+     *
+     * @return ResponseInterface
+     */
+    public function getUserByEmailAndPassword(string $email, string $password): ResponseInterface
+    {
+        return $this->request('verifyPassword', array_filter([
             'email' => $email,
             'password' => $password,
             'returnSecureToken' => true,

--- a/src/Firebase/Auth/CustomTokenGenerator.php
+++ b/src/Firebase/Auth/CustomTokenGenerator.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Kreait\Firebase\Auth;
+
+use Kreait\Firebase\ServiceAccount;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token;
+
+class CustomTokenGenerator
+{
+    /**
+     * @var Builder
+     */
+    private $builder;
+
+    /**
+     * @var Signer
+     */
+    private $signer;
+
+    /**
+     * @var ServiceAccount
+     */
+    private $serviceAccount;
+
+    public function __construct(ServiceAccount $serviceAccount, Builder $builder = null, Signer $signer = null)
+    {
+        $this->serviceAccount = $serviceAccount;
+        $this->signer = $signer ?? new Sha256();
+        $this->builder = $builder ?? $this->createBuilder();
+    }
+
+    /**
+     * Returns a token for the given user and claims.
+     *
+     * @param mixed $uid
+     * @param array $claims
+     * @param \DateTimeInterface $expiresAt
+     *
+     * @throws \BadMethodCallException when a claim is invalid
+     *
+     * @return Token
+     */
+    public function create($uid, array $claims = [], \DateTimeInterface $expiresAt = null): Token
+    {
+        if (count($claims)) {
+            $this->builder->set('claims', $claims);
+        }
+
+        $this->builder->set('uid', (string) $uid);
+
+        $now = time();
+        $expiration = $expiresAt ? $expiresAt->getTimestamp() : $now + (60 * 60);
+
+        return $this->builder
+            ->setIssuedAt($now)
+            ->setExpiration($expiration)
+            ->sign($this->signer, $this->serviceAccount->getPrivateKey())
+            ->getToken();
+    }
+
+    private function createBuilder(): Builder
+    {
+        return (new Builder())
+                ->setIssuer($this->serviceAccount->getClientEmail())
+                ->setSubject($this->serviceAccount->getClientEmail())
+                ->setAudience('https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit');
+    }
+}

--- a/src/Firebase/Auth/IdTokenVerifier.php
+++ b/src/Firebase/Auth/IdTokenVerifier.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Kreait\Firebase\Auth;
+
+use Kreait\Firebase\Exception\Auth\InvalidIdToken;
+use Kreait\Firebase\ServiceAccount;
+use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Token;
+
+class IdTokenVerifier
+{
+    /**
+     * @var ServiceAccount
+     */
+    private $serviceAccount;
+
+    public function __construct(ServiceAccount $serviceAccount)
+    {
+        $this->serviceAccount = $serviceAccount;
+    }
+
+    public function verify($token): Token
+    {
+        $token = $token instanceof Token ? $token : (new Parser())->parse($token);
+
+        $this->verifyExpiry($token);
+        $this->verifyIssuedAt($token);
+        $this->verifyIssuer($token);
+
+        return $token;
+    }
+
+    private function verifyExpiry(Token $token)
+    {
+        if (!$token->hasClaim('exp')) {
+            throw new InvalidIdToken('The claim "exp" is missing.');
+        }
+
+        if ($token->isExpired()) {
+            throw new InvalidIdToken('The token is expired.');
+        }
+    }
+
+    private function verifyIssuedAt(Token $token)
+    {
+        if (!$token->hasClaim('iat')) {
+            throw new InvalidIdToken('The claim "iat" is missing.');
+        }
+
+        if ($token->getClaim('iat') > time()) {
+            throw new InvalidIdToken('This token has been issued in the future.');
+        }
+    }
+
+    private function verifyIssuer(Token $token)
+    {
+        if (!$token->hasClaim('iss')) {
+            throw new InvalidIdToken('The claim "iss" is missing.');
+        }
+
+        if ($token->getClaim('iss') !== sprintf('https://securetoken.google.com/%s', $this->serviceAccount->getProjectId())) {
+            throw new InvalidIdToken('This token has an invalid issuer.');
+        }
+    }
+}

--- a/src/Firebase/Auth/IdTokenVerifier.php
+++ b/src/Firebase/Auth/IdTokenVerifier.php
@@ -26,6 +26,7 @@ class IdTokenVerifier
         $this->verifyExpiry($token);
         $this->verifyIssuedAt($token);
         $this->verifyIssuer($token);
+        $this->verifyAudience($token);
 
         return $token;
     }
@@ -49,6 +50,17 @@ class IdTokenVerifier
 
         if ($token->getClaim('iat') > time()) {
             throw new InvalidIdToken('This token has been issued in the future.');
+        }
+    }
+
+    private function verifyAudience(Token $token)
+    {
+        if (!$token->hasClaim('aud')) {
+            throw new InvalidIdToken('The claim "aud" is missing.');
+        }
+
+        if ($token->getClaim('aud') !== $this->serviceAccount->getProjectId()) {
+            throw new InvalidIdToken('This token has an invalid audience.');
         }
     }
 

--- a/src/Firebase/Auth/User.php
+++ b/src/Firebase/Auth/User.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Kreait\Firebase\Auth;
+
+use Kreait\Firebase\Auth\User\AuthInfo;
+use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Token;
+
+class User
+{
+    /**
+     * @var Token
+     */
+    private $idToken;
+
+    /**
+     * @var string
+     */
+    private $refreshToken;
+
+    public static function create($idToken = null, string $refreshToken = null): self
+    {
+        $idToken = $idToken instanceof Token ?: (new Parser())->parse($idToken);
+
+        $user = new static();
+        $user->setIdToken($idToken);
+        $user->setRefreshToken($refreshToken);
+
+        return $user;
+    }
+
+    public function setIdToken(Token $token)
+    {
+        $this->idToken = $token;
+    }
+
+    public function setRefreshToken(string $refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUid(): string
+    {
+        /* @noinspection ExceptionsAnnotatingAndHandlingInspection */
+        return (string) $this->idToken->getClaim('sub');
+    }
+
+    /**
+     * @return Token
+     */
+    public function getIdToken(): Token
+    {
+        return $this->idToken;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRefreshToken(): string
+    {
+        return $this->refreshToken;
+    }
+}

--- a/src/Firebase/Auth/User.php
+++ b/src/Firebase/Auth/User.php
@@ -2,7 +2,6 @@
 
 namespace Kreait\Firebase\Auth;
 
-use Kreait\Firebase\Auth\User\AuthInfo;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Token;
 

--- a/src/Firebase/Auth/User.php
+++ b/src/Firebase/Auth/User.php
@@ -44,7 +44,7 @@ class User
     public function getUid(): string
     {
         /* @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        return (string) $this->idToken->getClaim('sub');
+        return (string) $this->idToken->getClaim('user_id');
     }
 
     /**

--- a/src/Firebase/Database/ApiClient.php
+++ b/src/Firebase/Database/ApiClient.php
@@ -30,6 +30,7 @@ class ApiClient
 
         /** @var HandlerStack $stack */
         $stack = clone $config['handler'];
+        $stack->remove('auth_override');
         $stack->push(Middleware::overrideAuth($auth), 'auth_override');
 
         $config['handler'] = $stack;

--- a/src/Firebase/Database/Query/Filter/EqualTo.php
+++ b/src/Firebase/Database/Query/Filter/EqualTo.php
@@ -16,7 +16,7 @@ final class EqualTo implements Filter
 
     public function __construct($value)
     {
-        if ($value !== null && !is_scalar($value)) {
+        if (null !== $value && !is_scalar($value)) {
             throw new InvalidArgumentException('Only scalar values are allowed for "equalTo" queries.');
         }
 

--- a/src/Firebase/Database/Reference.php
+++ b/src/Firebase/Database/Reference.php
@@ -65,7 +65,7 @@ class Reference
     {
         $key = basename($this->getPath());
 
-        return $key !== '' ? $key : null;
+        return '' !== $key ? $key : null;
     }
 
     /**
@@ -91,7 +91,7 @@ class Reference
     {
         $parentPath = dirname($this->getPath());
 
-        if ($parentPath === '.') {
+        if ('.' === $parentPath) {
             throw new OutOfRangeException('Cannot get parent of root reference');
         }
 

--- a/src/Firebase/Database/Snapshot.php
+++ b/src/Firebase/Database/Snapshot.php
@@ -103,7 +103,7 @@ class Snapshot
      */
     public function exists(): bool
     {
-        return $this->value !== null;
+        return null !== $this->value;
     }
 
     /**
@@ -120,7 +120,7 @@ class Snapshot
         $path = trim($path, '/');
         $expression = str_replace('/', '.', $path);
 
-        return JmesPath\search($expression, $this->value) !== null;
+        return null !== JmesPath\search($expression, $this->value);
     }
 
     /**

--- a/src/Firebase/Exception/Auth/CredentialsMismatch.php
+++ b/src/Firebase/Exception/Auth/CredentialsMismatch.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class CredentialsMismatch extends AuthException
+{
+    const IDENTIFER = 'CREDENTIALS_MISMATCH';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'Invalid custom token: The custom token corresponds to a different Firebase project.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/Auth/EmailExists.php
+++ b/src/Firebase/Exception/Auth/EmailExists.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class EmailExists extends AuthException
+{
+    const IDENTIFIER = 'EMAIL_EXISTS';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'The email address is already in use by another account.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/Auth/EmailNotFound.php
+++ b/src/Firebase/Exception/Auth/EmailNotFound.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class EmailNotFound extends AuthException
+{
+    const IDENTIFIER = 'EMAIL_NOT_FOUND';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'There is no user record corresponding to this identifier. The user may have been deleted.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/Auth/InvalidCustomToken.php
+++ b/src/Firebase/Exception/Auth/InvalidCustomToken.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class InvalidCustomToken extends AuthException
+{
+    const IDENTIFER = 'INVALID_CUSTOM_TOKEN';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'Invalid custom token: The custom token format is incorrect or'
+            .' the token is invalid for some reason (e.g. expired, invalid signature, etc.)';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/Auth/InvalidIdToken.php
+++ b/src/Firebase/Exception/Auth/InvalidIdToken.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+
+class InvalidIdToken extends AuthException
+{
+}

--- a/src/Firebase/Exception/Auth/InvalidPassword.php
+++ b/src/Firebase/Exception/Auth/InvalidPassword.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class InvalidPassword extends AuthException
+{
+    const IDENTIFIER = 'INVALID_PASSWORD';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'The password is invalid or the user does not have a password.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/Auth/MissingPassword.php
+++ b/src/Firebase/Exception/Auth/MissingPassword.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class MissingPassword extends AuthException
+{
+    const IDENTIFIER = 'MISSING_PASSWORD';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'Missing Password: An email user must have a password.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/Auth/OperationNotAllowed.php
+++ b/src/Firebase/Exception/Auth/OperationNotAllowed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class OperationNotAllowed extends AuthException
+{
+    const IDENTIFER = 'OPERATION_NOT_ALLOWED';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'Operation not allowed.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/Auth/UserDisabled.php
+++ b/src/Firebase/Exception/Auth/UserDisabled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class UserDisabled extends AuthException
+{
+    const IDENTIFER = 'USER_DISABLED';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'User disabled: The user account has been disabled by an administrator.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/Auth/WeakPassword.php
+++ b/src/Firebase/Exception/Auth/WeakPassword.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Throwable;
+
+class WeakPassword extends AuthException
+{
+    const IDENTIFIER = 'WEAK_PASSWORD';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'Weak Password: The password must be 6 characters long or more.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/AuthException.php
+++ b/src/Firebase/Exception/AuthException.php
@@ -5,7 +5,9 @@ namespace Kreait\Firebase\Exception;
 use GuzzleHttp\Exception\RequestException;
 use Kreait\Firebase\Exception\Auth\CredentialsMismatch;
 use Kreait\Firebase\Exception\Auth\EmailExists;
+use Kreait\Firebase\Exception\Auth\EmailNotFound;
 use Kreait\Firebase\Exception\Auth\InvalidCustomToken;
+use Kreait\Firebase\Exception\Auth\InvalidPassword;
 use Kreait\Firebase\Exception\Auth\MissingPassword;
 use Kreait\Firebase\Exception\Auth\OperationNotAllowed;
 use Kreait\Firebase\Exception\Auth\UserDisabled;
@@ -17,7 +19,9 @@ class AuthException extends \RuntimeException implements FirebaseException
     public static $errors = [
         CredentialsMismatch::IDENTIFER => CredentialsMismatch::class,
         EmailExists::IDENTIFIER => EmailExists::class,
+        EmailNotFound::IDENTIFIER => EmailNotFound::class,
         InvalidCustomToken::IDENTIFER => InvalidCustomToken::class,
+        InvalidPassword::IDENTIFIER => InvalidPassword::class,
         MissingPassword::IDENTIFIER => MissingPassword::class,
         OperationNotAllowed::IDENTIFER => OperationNotAllowed::class,
         UserDisabled::IDENTIFER => UserDisabled::class,

--- a/src/Firebase/Exception/AuthException.php
+++ b/src/Firebase/Exception/AuthException.php
@@ -7,6 +7,7 @@ use Kreait\Firebase\Exception\Auth\CredentialsMismatch;
 use Kreait\Firebase\Exception\Auth\EmailExists;
 use Kreait\Firebase\Exception\Auth\InvalidCustomToken;
 use Kreait\Firebase\Exception\Auth\MissingPassword;
+use Kreait\Firebase\Exception\Auth\UserDisabled;
 use Kreait\Firebase\Exception\Auth\WeakPassword;
 use Kreait\Firebase\Util\JSON;
 
@@ -18,6 +19,7 @@ class AuthException extends \RuntimeException implements FirebaseException
         WeakPassword::IDENTIFIER => WeakPassword::class,
         EmailExists::IDENTIFIER => EmailExists::class,
         MissingPassword::IDENTIFIER => MissingPassword::class,
+        UserDisabled::IDENTIFER => UserDisabled::class,
     ];
 
     /**

--- a/src/Firebase/Exception/AuthException.php
+++ b/src/Firebase/Exception/AuthException.php
@@ -46,7 +46,7 @@ class AuthException extends \RuntimeException implements FirebaseException
         $message = $errors['error']['message'] ?? $message;
 
         $candidates = array_filter(array_map(function ($key, $class) use ($message, $e) {
-            return stripos($message, $key) !== false
+            return false !== stripos($message, $key)
                 ? new $class($e->getCode(), $e)
                 : null;
         }, array_keys(self::$errors), self::$errors));

--- a/src/Firebase/Exception/AuthException.php
+++ b/src/Firebase/Exception/AuthException.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Kreait\Firebase\Exception;
+
+use GuzzleHttp\Exception\RequestException;
+use Kreait\Firebase\Exception\Auth\CredentialsMismatch;
+use Kreait\Firebase\Exception\Auth\EmailExists;
+use Kreait\Firebase\Exception\Auth\InvalidCustomToken;
+use Kreait\Firebase\Exception\Auth\MissingPassword;
+use Kreait\Firebase\Exception\Auth\WeakPassword;
+use Kreait\Firebase\Util\JSON;
+
+class AuthException extends \RuntimeException implements FirebaseException
+{
+    public static $errors = [
+        InvalidCustomToken::IDENTIFER => InvalidCustomToken::class,
+        CredentialsMismatch::IDENTIFER => CredentialsMismatch::class,
+        WeakPassword::IDENTIFIER => WeakPassword::class,
+        EmailExists::IDENTIFIER => EmailExists::class,
+        MissingPassword::IDENTIFIER => MissingPassword::class,
+    ];
+
+    /**
+     * @param RequestException $e
+     *
+     * @return self
+     */
+    public static function fromRequestException(RequestException $e): self
+    {
+        $message = $e->getMessage();
+
+        if (!($response = $e->getResponse())) {
+            return new static($message, $e->getCode(), $e);
+        }
+
+        try {
+            $errors = JSON::decode((string) $response->getBody(), true);
+        } catch (\InvalidArgumentException $jsonDecodeException) {
+            return new static('Invalid JSON: The API returned an invalid JSON string.', $e->getCode(), $e);
+        }
+
+        $message = $errors['error']['message'] ?? $message;
+
+        $candidates = array_filter(array_map(function ($key, $class) use ($message, $e) {
+            return stripos($message, $key) !== false ? new $class($e->getCode(), $e) : null;
+        }, array_keys(self::$errors), self::$errors));
+
+        $fallback = new static(sprintf('Unknown error: "%s"', $message), $e->getCode(), $e);
+
+        return array_shift($candidates) ?? $fallback;
+    }
+}

--- a/src/Firebase/Exception/AuthException.php
+++ b/src/Firebase/Exception/AuthException.php
@@ -7,6 +7,7 @@ use Kreait\Firebase\Exception\Auth\CredentialsMismatch;
 use Kreait\Firebase\Exception\Auth\EmailExists;
 use Kreait\Firebase\Exception\Auth\InvalidCustomToken;
 use Kreait\Firebase\Exception\Auth\MissingPassword;
+use Kreait\Firebase\Exception\Auth\OperationNotAllowed;
 use Kreait\Firebase\Exception\Auth\UserDisabled;
 use Kreait\Firebase\Exception\Auth\WeakPassword;
 use Kreait\Firebase\Util\JSON;
@@ -14,12 +15,13 @@ use Kreait\Firebase\Util\JSON;
 class AuthException extends \RuntimeException implements FirebaseException
 {
     public static $errors = [
-        InvalidCustomToken::IDENTIFER => InvalidCustomToken::class,
         CredentialsMismatch::IDENTIFER => CredentialsMismatch::class,
-        WeakPassword::IDENTIFIER => WeakPassword::class,
         EmailExists::IDENTIFIER => EmailExists::class,
+        InvalidCustomToken::IDENTIFER => InvalidCustomToken::class,
         MissingPassword::IDENTIFIER => MissingPassword::class,
+        OperationNotAllowed::IDENTIFER => OperationNotAllowed::class,
         UserDisabled::IDENTIFER => UserDisabled::class,
+        WeakPassword::IDENTIFIER => WeakPassword::class,
     ];
 
     /**
@@ -44,7 +46,9 @@ class AuthException extends \RuntimeException implements FirebaseException
         $message = $errors['error']['message'] ?? $message;
 
         $candidates = array_filter(array_map(function ($key, $class) use ($message, $e) {
-            return stripos($message, $key) !== false ? new $class($e->getCode(), $e) : null;
+            return stripos($message, $key) !== false
+                ? new $class($e->getCode(), $e)
+                : null;
         }, array_keys(self::$errors), self::$errors));
 
         $fallback = new static(sprintf('Unknown error: "%s"', $message), $e->getCode(), $e);

--- a/src/Firebase/Exception/QueryException.php
+++ b/src/Firebase/Exception/QueryException.php
@@ -24,14 +24,14 @@ class QueryException extends \RuntimeException implements FirebaseException
     {
         $message = $e->getMessage();
 
-        if (stripos($message, 'index not defined') !== false) {
+        if (false !== stripos($message, 'index not defined')) {
             throw new IndexNotDefined($query, $message, $e->getCode(), $e);
         }
 
-        if (stripos($message, 'orderby must be defined') !== false) {
+        if (false !== stripos($message, 'orderby must be defined')) {
             $message = 'An order must be defined for a query when applying filters.'
                 .' You can use Query::orderByValue(), Query::orderByKey() or Query::orderByChild().';
-        } elseif (stripos($message, 'key index passed non') !== false) {
+        } elseif (false !== stripos($message, 'key index passed non')) {
             $message = 'The query is ordered by key, but you tried to filter it with a non-string value.';
         }
 

--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -3,8 +3,12 @@
 namespace Kreait\Firebase;
 
 use Firebase\Auth\Token\Handler as TokenHandler;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
 use Kreait\Firebase;
+use Kreait\Firebase\Auth\CustomTokenGenerator;
+use Kreait\Firebase\Http\Middleware;
 use Kreait\Firebase\ServiceAccount\Discoverer;
 use Psr\Http\Message\UriInterface;
 
@@ -30,11 +34,15 @@ final class Factory
      */
     private $serviceAccountDiscoverer;
 
+    /**
+     * @var string|null
+     */
+    private $apiKey;
+
     private static $databaseUriPattern = 'https://%s.firebaseio.com';
 
     /**
      * @deprecated 3.1 use {@see withServiceAccount()} instead
-     * @codeCoverageIgnore
      *
      * @param string $credentials Path to a credentials file
      *
@@ -52,10 +60,51 @@ final class Factory
         return $this->withServiceAccount(ServiceAccount::fromValue($credentials));
     }
 
+    /**
+     * @deprecated 3.2 use {@see withServiceAccountAndApiKey()} instead
+     *
+     * @param string $apiKey
+     *
+     * @return Factory
+     */
+    public function withApiKey(string $apiKey): self
+    {
+        trigger_error(
+            'This method is deprecated and will be removed in release 4.0 of this library.'
+            .' Use Firebase\Factory::withServiceAccountAndApiKey() instead.', E_USER_DEPRECATED
+        );
+
+        $factory = clone $this;
+        $factory->apiKey = $apiKey;
+
+        return $factory;
+    }
+
+    /**
+     * @deprecated 3.2 use {@see withServiceAccountAndApiKey()} instead
+     *
+     * @param ServiceAccount $serviceAccount
+     *
+     * @return self
+     */
     public function withServiceAccount(ServiceAccount $serviceAccount): self
+    {
+        trigger_error(
+            'This method is deprecated and will be removed in release 4.0 of this library.'
+            .' Use Firebase\Factory::withServiceAccountAndApiKey() instead.', E_USER_DEPRECATED
+        );
+
+        $factory = clone $this;
+        $factory->serviceAccount = $serviceAccount;
+
+        return $factory;
+    }
+
+    public function withServiceAccountAndApiKey(ServiceAccount $serviceAccount, string $apiKey): self
     {
         $factory = clone $this;
         $factory->serviceAccount = $serviceAccount;
+        $factory->apiKey = $apiKey;
 
         return $factory;
     }
@@ -76,8 +125,20 @@ final class Factory
         return $factory;
     }
 
+    /**
+     * @deprecated 3.2
+     *
+     * @param TokenHandler $handler
+     *
+     * @return Factory
+     */
     public function withTokenHandler(TokenHandler $handler): self
     {
+        trigger_error(
+            'The token handler is deprecated and will be removed in release 4.0 of this library.'
+            .' Use Firebase\Auth::createCustomToken() instead.', E_USER_DEPRECATED
+        );
+
         $factory = clone $this;
         $factory->tokenHandler = $handler;
 
@@ -89,8 +150,10 @@ final class Factory
         $serviceAccount = $this->serviceAccount ?? $this->getServiceAccountDiscoverer()->discover();
         $databaseUri = $this->databaseUri ?? $this->getDatabaseUriFromServiceAccount($serviceAccount);
         $tokenHandler = $this->tokenHandler ?? $this->getDefaultTokenHandler($serviceAccount);
+        $tokenGenerator = new CustomTokenGenerator($serviceAccount);
+        $auth = $this->apiKey ? $this->createAuth($this->apiKey, $tokenGenerator) : null;
 
-        return new Firebase($serviceAccount, $databaseUri, $tokenHandler);
+        return new Firebase($serviceAccount, $databaseUri, $tokenHandler, $auth);
     }
 
     private function getServiceAccountDiscoverer(): Discoverer
@@ -110,5 +173,25 @@ final class Factory
             $serviceAccount->getClientEmail(),
             $serviceAccount->getPrivateKey()
         );
+    }
+
+    private function createAuth(string $apiKey, CustomTokenGenerator $customTokenGenerator): Auth
+    {
+        $client = $this->createAuthApiClient($apiKey);
+
+        return new Auth($client, $customTokenGenerator);
+    }
+
+    private function createAuthApiClient(string $apiKey): Firebase\Auth\ApiClient
+    {
+        $stack = HandlerStack::create();
+        $stack->push(Middleware::ensureApiKey($apiKey), 'ensure_api_key');
+
+        $httpClient = new Client([
+            'base_uri' => 'https://www.googleapis.com/identitytoolkit/v3/relyingparty/',
+            'handler' => $stack,
+        ]);
+
+        return new Firebase\Auth\ApiClient($httpClient);
     }
 }

--- a/src/Firebase/Http/Auth/CustomToken.php
+++ b/src/Firebase/Http/Auth/CustomToken.php
@@ -17,7 +17,7 @@ final class CustomToken implements Auth
     public function __construct(string $uid, array $claims = [])
     {
         $claims = array_filter($claims, function ($value) {
-            return $value !== null;
+            return null !== $value;
         });
 
         $claims = ['uid' => $uid] + $claims;

--- a/src/Firebase/Http/Auth/UserAuth.php
+++ b/src/Firebase/Http/Auth/UserAuth.php
@@ -3,36 +3,27 @@
 namespace Kreait\Firebase\Http\Auth;
 
 use GuzzleHttp\Psr7;
+use Kreait\Firebase\Auth\User;
 use Kreait\Firebase\Http\Auth;
-use Kreait\Firebase\Util\JSON;
 use Psr\Http\Message\RequestInterface;
 
-final class CustomToken implements Auth
+final class UserAuth implements Auth
 {
     /**
      * @var string
      */
     private $token;
 
-    /**
-     * @deprecated 3.2
-     */
-    public function __construct(string $uid, array $claims = [])
+    public function __construct(User $user)
     {
-        $claims = array_filter($claims, function ($value) {
-            return null !== $value;
-        });
-
-        $claims = ['uid' => $uid] + $claims;
-
-        $this->token = JSON::encode($claims);
+        $this->token = $user->getIdToken();
     }
 
     public function authenticateRequest(RequestInterface $request): RequestInterface
     {
         $uri = $request->getUri();
 
-        $queryParams = ['auth_variable_override' => $this->token] + Psr7\parse_query($uri->getQuery());
+        $queryParams = ['auth' => $this->token] + Psr7\parse_query($uri->getQuery());
         $queryString = Psr7\build_query($queryParams);
 
         $newUri = $uri->withQuery($queryString);

--- a/src/Firebase/Http/Middleware.php
+++ b/src/Firebase/Http/Middleware.php
@@ -19,7 +19,7 @@ class Middleware
                 $uri = $request->getUri();
                 $path = $uri->getPath();
 
-                if (substr($path, -5) !== '.json') {
+                if ('.json' !== substr($path, -5)) {
                     /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
                     $uri = $uri->withPath($path.'.json');
                     $request = $request->withUri($uri);

--- a/src/Firebase/Http/Middleware.php
+++ b/src/Firebase/Http/Middleware.php
@@ -2,6 +2,7 @@
 
 namespace Kreait\Firebase\Http;
 
+use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 
 class Middleware
@@ -41,6 +42,32 @@ class Middleware
         return function (callable $handler) use ($override) {
             return function (RequestInterface $request, array $options = []) use ($handler, $override) {
                 return $handler($override->authenticateRequest($request), $options);
+            };
+        };
+    }
+
+    /**
+     * Ensures that the API Key is present as a query parameter.
+     *
+     * @param string $apiKey
+     *
+     * @return callable
+     */
+    public static function ensureApiKey(string $apiKey): callable
+    {
+        return function (callable $handler) use ($apiKey) {
+            return function (RequestInterface $request, array $options = []) use ($handler, $apiKey) {
+                $uri = $request->getUri();
+
+                $queryParams = ['key' => $apiKey] + Psr7\parse_query($uri->getQuery());
+
+                /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
+                $newUri = $uri->withQuery(Psr7\build_query($queryParams));
+
+                /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
+                $request = $request->withUri($newUri);
+
+                return $handler($request, $options);
             };
         };
     }

--- a/tests/Firebase/Auth/CustomTokenGeneratorTest.php
+++ b/tests/Firebase/Auth/CustomTokenGeneratorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Kreait\Tests\Firebase\Auth;
+
+use Kreait\Firebase\Auth\CustomTokenGenerator;
+use Kreait\Tests\FirebaseTestCase;
+
+class CustomTokenGeneratorTest extends FirebaseTestCase
+{
+    /**
+     * @var CustomTokenGenerator
+     */
+    private $generator;
+
+    protected function setUp()
+    {
+        $this->generator = new CustomTokenGenerator($this->createServiceAccountMock());
+    }
+
+    public function testCreateWithUidOnly()
+    {
+        $token = $this->generator->create('uid');
+
+        $this->assertSame('uid', $token->getClaim('uid'));
+    }
+
+    public function testCreateWithClaims()
+    {
+        $claims = ['first' => 'value', 'second' => 1, 'third' => true];
+
+        $token = $this->generator->create('uid', $claims);
+
+        $this->assertSame($claims, $token->getClaim('claims'));
+    }
+
+    public function testWithCustomExpiration()
+    {
+        $expiresAt = (new \DateTimeImmutable())->modify('+1337 minutes');
+        $token = $this->generator->create('uid', [], $expiresAt);
+
+        $this->assertSame($expiresAt->getTimestamp(), $token->getClaim('exp'));
+    }
+}

--- a/tests/Firebase/Auth/IdTokenVerifierTest.php
+++ b/tests/Firebase/Auth/IdTokenVerifierTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Kreait\Tests\Firebase\Auth;
+
+use Kreait\Firebase\Auth\IdTokenVerifier;
+use Kreait\Firebase\Exception\Auth\InvalidIdToken;
+use Kreait\Tests\FirebaseTestCase;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Token;
+
+class IdTokenVerifierTest extends FirebaseTestCase
+{
+    /**
+     * @var IdTokenVerifier
+     */
+    private $verifier;
+
+    protected function setUp()
+    {
+        $serviceAccount = $this->createServiceAccountMock();
+        $this->verifier = new IdTokenVerifier($serviceAccount);
+    }
+
+    /**
+     * @param Token $token
+     *
+     * @dataProvider validTokenProvider
+     */
+    public function testItSucceedsWithAValidToken($token)
+    {
+        $this->assertInstanceOf(Token::class, $this->verifier->verify($token));
+    }
+
+    /**
+     * @param string $token
+     *
+     * @dataProvider validTokenStringProvider
+     */
+    public function testItCanHandlAStringTokens($token)
+    {
+        $this->assertInstanceOf(Token::class, $this->verifier->verify($token));
+    }
+
+    /**
+     * @param Token $token
+     * @param string $exception
+     * @dataProvider invalidTokenProvider
+     */
+    public function testInvalidTokenResultsInException(Token $token, $exception)
+    {
+        $this->expectException($exception);
+
+        $this->verifier->verify($token);
+    }
+
+    public function validTokenProvider()
+    {
+        return [
+            [(new Builder())
+                ->setExpiration(time() + 1800)
+                ->setIssuedAt(time() - 10)
+                ->setIssuer('https://securetoken.google.com/project')
+                ->getToken(),
+            ],
+        ];
+    }
+
+    public function validTokenStringProvider()
+    {
+        return [
+            [(string) (new Builder())
+                ->setExpiration(time() + 1800)
+                ->setIssuedAt(time() - 10)
+                ->setIssuer('https://securetoken.google.com/project')
+                ->getToken(),
+            ],
+        ];
+    }
+
+    public function invalidTokenProvider()
+    {
+        $builder = new Builder();
+
+        return [
+            'no_exp_claim' => [
+                $builder->getToken(),
+                InvalidIdToken::class,
+            ],
+            'expired' => [
+                $builder
+                    ->setExpiration(time() - 10)
+                    ->getToken(),
+                InvalidIdToken::class,
+            ],
+            'no_iat_claim' => [
+                $builder
+                    ->setExpiration(time() + 1800)
+                    ->getToken(),
+                InvalidIdToken::class,
+            ],
+            'not_yet_issued' => [
+                $builder
+                    ->setExpiration(time() + 1800)
+                    ->setIssuedAt(time() + 1800)
+                    ->getToken(),
+                InvalidIdToken::class,
+            ],
+            'no_iss_claim' => [
+                $builder
+                    ->setExpiration(time() + 1800)
+                    ->setIssuedAt(time() - 10)
+                    ->getToken(),
+                InvalidIdToken::class,
+            ],
+            'invalid_issuer' => [
+                $builder
+                    ->setExpiration(time() + 1800)
+                    ->setIssuedAt(time() - 10)
+                    ->setIssuer('invalid_issuer')
+                    ->getToken(),
+                InvalidIdToken::class,
+            ],
+        ];
+    }
+}

--- a/tests/Firebase/Auth/IdTokenVerifierTest.php
+++ b/tests/Firebase/Auth/IdTokenVerifierTest.php
@@ -59,6 +59,7 @@ class IdTokenVerifierTest extends FirebaseTestCase
             [(new Builder())
                 ->setExpiration(time() + 1800)
                 ->setIssuedAt(time() - 10)
+                ->setAudience('project')
                 ->setIssuer('https://securetoken.google.com/project')
                 ->getToken(),
             ],
@@ -71,6 +72,7 @@ class IdTokenVerifierTest extends FirebaseTestCase
             [(string) (new Builder())
                 ->setExpiration(time() + 1800)
                 ->setIssuedAt(time() - 10)
+                ->setAudience('project')
                 ->setIssuer('https://securetoken.google.com/project')
                 ->getToken(),
             ],
@@ -117,6 +119,23 @@ class IdTokenVerifierTest extends FirebaseTestCase
                     ->setExpiration(time() + 1800)
                     ->setIssuedAt(time() - 10)
                     ->setIssuer('invalid_issuer')
+                    ->getToken(),
+                InvalidIdToken::class,
+            ],
+            'no_aud_claim' => [
+                $builder
+                    ->setExpiration(time() + 1800)
+                    ->setIssuedAt(time() - 10)
+                    ->setIssuer('project')
+                    ->getToken(),
+                InvalidIdToken::class,
+            ],
+            'no_audience' => [
+                $builder
+                    ->setExpiration(time() + 1800)
+                    ->setIssuedAt(time() - 10)
+                    ->setIssuer('project')
+                    ->setAudience('project')
                     ->getToken(),
                 InvalidIdToken::class,
             ],

--- a/tests/Firebase/AuthTest.php
+++ b/tests/Firebase/AuthTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Kreait\Tests\Firebase;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use Kreait\Firebase\Auth;
+use Kreait\Tests\FirebaseTestCase;
+use Lcobucci\JWT\Token;
+
+class AuthTest extends FirebaseTestCase
+{
+    /**
+     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $httpClient;
+
+    /**
+     * @var Auth\ApiClient
+     */
+    private $apiClient;
+
+    /**
+     * @var Auth\CustomTokenGenerator
+     */
+    private $tokenGenerator;
+
+    /**
+     * @var Auth
+     */
+    private $auth;
+
+    protected function setUp()
+    {
+        $this->tokenGenerator = new Auth\CustomTokenGenerator($this->createServiceAccountMock());
+        $this->httpClient = $this->createMock(Client::class);
+        $this->apiClient = new Auth\ApiClient($this->httpClient);
+        $this->auth = new Auth($this->apiClient, $this->tokenGenerator);
+    }
+
+    public function testGetApiClient()
+    {
+        $this->assertSame($this->apiClient, $this->auth->getApiClient());
+    }
+
+    public function testCreateCustomToken()
+    {
+        $this->assertInstanceOf(Token::class, $this->auth->createCustomToken('uid'));
+    }
+
+    public function testCreateUser()
+    {
+        $this->markTestSkipped('We have to test this with integration tests.');
+        $this->assertInstanceOf(Auth\User::class, $this->auth->getUser('uid'));
+    }
+}

--- a/tests/Firebase/AuthTest.php
+++ b/tests/Firebase/AuthTest.php
@@ -21,9 +21,14 @@ class AuthTest extends FirebaseTestCase
     private $apiClient;
 
     /**
-     * @var Auth\CustomTokenGenerator
+     * @var Auth\CustomTokenGenerator|\PHPUnit_Framework_MockObject_MockObject
      */
     private $tokenGenerator;
+
+    /**
+     * @var Auth\IdTokenVerifier|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $idTokenVerifier;
 
     /**
      * @var Auth
@@ -32,10 +37,11 @@ class AuthTest extends FirebaseTestCase
 
     protected function setUp()
     {
-        $this->tokenGenerator = new Auth\CustomTokenGenerator($this->createServiceAccountMock());
+        $this->tokenGenerator = $this->createMock(Auth\CustomTokenGenerator::class);
+        $this->idTokenVerifier = $this->createMock(Auth\IdTokenVerifier::class);
         $this->httpClient = $this->createMock(Client::class);
         $this->apiClient = new Auth\ApiClient($this->httpClient);
-        $this->auth = new Auth($this->apiClient, $this->tokenGenerator);
+        $this->auth = new Auth($this->apiClient, $this->tokenGenerator, $this->idTokenVerifier);
     }
 
     public function testGetApiClient()
@@ -45,7 +51,19 @@ class AuthTest extends FirebaseTestCase
 
     public function testCreateCustomToken()
     {
+        $this->tokenGenerator
+            ->expects($this->once())
+            ->method('create');
         $this->assertInstanceOf(Token::class, $this->auth->createCustomToken('uid'));
+    }
+
+    public function testVerifyIdToken()
+    {
+        $this->idTokenVerifier
+            ->expects($this->once())
+            ->method('verify');
+
+        $this->auth->verifyIdToken('some id token string');
     }
 
     public function testCreateUser()

--- a/tests/Firebase/Exception/AuthExceptionTest.php
+++ b/tests/Firebase/Exception/AuthExceptionTest.php
@@ -54,7 +54,7 @@ class AuthExceptionTest extends FirebaseTestCase
     {
         foreach (AuthException::$errors as $identifier => $exceptionClass) {
             $error = $this->createFirebaseError(sprintf('foo %s bar', $identifier));
-            
+
             $e = AuthException::fromRequestException($error);
 
             $this->assertInstanceOf($exceptionClass, $e);

--- a/tests/Firebase/Exception/AuthExceptionTest.php
+++ b/tests/Firebase/Exception/AuthExceptionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Kreait\Tests\Firebase\Exception;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Response;
+use Kreait\Firebase\Exception\Auth\InvalidCustomToken;
+use Kreait\Firebase\Exception\AuthException;
+use Kreait\Tests\FirebaseTestCase;
+use Psr\Http\Message\RequestInterface;
+
+class AuthExceptionTest extends FirebaseTestCase
+{
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    protected function setUp()
+    {
+        $this->request = $this->createMock(RequestInterface::class);
+    }
+
+    public function testWithoutResponse()
+    {
+        $re = new RequestException('foo', $this->createMock(RequestInterface::class));
+        $e = AuthException::fromRequestException($re);
+
+        $this->assertInstanceOf(AuthException::class, $e);
+        $this->assertSame('foo', $e->getMessage());
+    }
+
+    public function testWithInvalidJson()
+    {
+        $re = new RequestException(
+            'foo',
+            $this->createMock(RequestInterface::class),
+            new Response(400, [], '{')
+        );
+
+        $this->assertRegExp('/json/i', AuthException::fromRequestException($re)->getMessage());
+    }
+
+    public function testUnknownError()
+    {
+        $error = $this->createFirebaseError('foo');
+
+        $e = AuthException::fromRequestException($error);
+
+        $this->assertInstanceOf(AuthException::class, $e);
+    }
+
+    public function testErrors()
+    {
+        foreach (AuthException::$errors as $identifier => $exceptionClass) {
+            $error = $this->createFirebaseError(sprintf('foo %s bar', $identifier));
+            
+            $e = AuthException::fromRequestException($error);
+
+            $this->assertInstanceOf($exceptionClass, $e);
+        }
+    }
+
+    public function testMissingPassword()
+    {
+        $error = $this->createFirebaseError('foo INVALID_CUSTOM_TOKEN bar');
+
+        $e = AuthException::fromRequestException($error);
+
+        $this->assertInstanceOf(InvalidCustomToken::class, $e);
+    }
+
+    private function createFirebaseError(string $message): RequestException
+    {
+        return new RequestException(
+            'Firebase Error Test',
+            $this->createMock(RequestInterface::class),
+            new Response(400, [], json_encode([
+                'error' => [
+                    'errors' => [
+                        'domain' => 'global',
+                        'reason' => 'invalid',
+                        'message' => $message,
+                    ],
+                    'code' => 400,
+                    'message' => $message,
+                ],
+            ]))
+        );
+    }
+}

--- a/tests/Firebase/FactoryTest.php
+++ b/tests/Firebase/FactoryTest.php
@@ -4,6 +4,7 @@ namespace Kreait\Tests\Firebase;
 
 use Firebase\Auth\Token\Handler;
 use Kreait\Firebase;
+use Kreait\Firebase\Auth;
 use Kreait\Firebase\Factory;
 use Kreait\Firebase\ServiceAccount\Discoverer;
 use Kreait\Tests\FirebaseTestCase;
@@ -50,10 +51,38 @@ class FactoryTest extends FirebaseTestCase
         $this->assertSame($handler, $firebase->getTokenHandler());
     }
 
+    public function testItAcceptsCredentials()
+    {
+        $firebase = $this->factory
+            ->withCredentials($this->fixturesDir.'/ServiceAccount/valid.json')
+            ->create();
+
+        $this->assertInstanceOf(Firebase::class, $firebase);
+    }
+
     public function testItAcceptsAServiceAccount()
     {
         $firebase = $this->factory
             ->withServiceAccount($this->createServiceAccountMock())
+            ->create();
+
+        $this->assertInstanceOf(Firebase::class, $firebase);
+    }
+
+    public function testItAcceptsAnApiKey()
+    {
+        $firebase = $this->factory
+            ->withApiKey('foo')
+            ->create();
+
+        $this->assertInstanceOf(Firebase::class, $firebase);
+        $this->assertInstanceOf(Auth::class, $firebase->getAuth());
+    }
+
+    public function testItAcceptsAServiceAccountAndApiKey()
+    {
+        $firebase = $this->factory
+            ->withServiceAccountAndApiKey($this->createServiceAccountMock(), 'some key')
             ->create();
 
         $this->assertInstanceOf(Firebase::class, $firebase);

--- a/tests/Firebase/Http/MiddlewareTest.php
+++ b/tests/Firebase/Http/MiddlewareTest.php
@@ -39,6 +39,20 @@ class MiddlewareTest extends FirebaseTestCase
         $this->assertStringEndsWith('.json', $request->getUri()->getPath());
     }
 
+    public function testEnsureApiKey()
+    {
+        $middleware = Middleware::ensureApiKey('foo');
+
+        $handlerClosure = $middleware($this->handler);
+        /** @var RequestInterface $request */
+        $request = $handlerClosure($this->request);
+
+        $this->assertInstanceOf(RequestInterface::class, $request);
+        $queryParams = Psr7\parse_query($request->getUri()->getQuery());
+
+        $this->assertArraySubset(['key' => 'foo'], $queryParams);
+    }
+
     public function testOverrideAuth()
     {
         $authenticatedRequest = new Psr7\Request('GET', 'http://domain.tld?is_authenticated=true'); // Doesn't matter :)

--- a/tests/FirebaseTest.php
+++ b/tests/FirebaseTest.php
@@ -65,4 +65,11 @@ class FirebaseTest extends FirebaseTestCase
     {
         $this->assertInstanceOf(Handler::class, $this->firebase->getTokenHandler());
     }
+
+    public function testGetUnconfiguredAuth()
+    {
+        $this->expectException(Firebase\Exception\LogicException::class);
+
+        $this->firebase->getAuth();
+    }
 }

--- a/tests/FirebaseTestCase.php
+++ b/tests/FirebaseTestCase.php
@@ -30,7 +30,21 @@ abstract class FirebaseTestCase extends TestCase
 
         $mock->expects($this->any())
             ->method('getPrivateKey')
-        ->willReturn('some private key');
+        ->willReturn('-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQC9fUon04iPvcWzwNwMLkiNQizaid+DaUdyv759FfbRxfj7hTWT
+BwWxdPMRc7bVGcaPSD4ZzTB8EyiwjfZw5FuunHhC90ihtRS3CULrcLOtZdyY0OXo
+dLyg0+r74hI64DAUUm8Q3XE81ZMpZD8ZX12EsjGH6cWkSlW0/q8NsL6llwIDAQAB
+AoGBALFkXozEOl8esLuj/BynI6KiZe09D3Mtlwa0vLbLXiJqLLoCrfHzq//CVV9s
+Lah4FevDHOf4sMAnC3ulmyV6ktxavVi0cAFN9VRg/Rqszh8FO5FfPqYLmC+ruEBq
+/lun5f7JG66SUIGlN5QsewqFISAwEOWA+4IN6zsUdrlbo1shAkEA5cMToo8osqKO
+WNbuEb+HmxstHNpdbpM/6Lmp3TVtebH/9KtnDT/XkrlSC5GBqkRDOxslP7XIzZPR
++yzzok4VsQJBANMg335p9g/Q/vl+fxrhBXHaKm2mRO+yDeoA+OEWeRRz6Y0RHKFI
+12cwX+XZEiJc+azb68vmxzk5Gfavy+ClmccCQH7gUJFt+I1ckrqgRWrrlxih0zGh
+rAKJsbrz+8c537BaCPu1QvzgCkztpU7aFP5PH8kd3l3mJnLPdB793bP85qECQQCp
+sk5xCTIh3FZUqvv22s7JiBV6NJ5MGs1cPJPON4Xyjog2Pn7IlAeuhQ9Pa35L6Hc2
+HT4VkdSnheH8iahRVEmZAkBRGoQz5HSLMfyb/zsxpCrUZv886exZ/tGEhuY3s1j6
+npI3CJzFaivN28EWmBJI4/pJtTATlNsKfLxCKUvCJ55k
+-----END RSA PRIVATE KEY-----');
 
         return $mock;
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+error_reporting(E_ALL & ~E_USER_DEPRECATED);


### PR DESCRIPTION
This is a pull request to track the progress of implementing Firebase Authentication and User Management features (https://firebase.google.com/docs/reference/rest/auth/)

## How to test

⚠️ **Method names and signatures might change** ⚠️ 

If you want to test it, you can do this by adding/replacing this line in your `composer.json`:

```
"require": {
    ...
    "kreait/firebase-php": "dev-feature/auth"
    ...
}
```

You can then activate and use the Authentication sub API by using your project's Web API key with the Firebase factory:

```php
require __DIR__.'/vendor/autoload.php';

use Kreait\Firebase\Exception\AuthException;
use Kreait\Firebase\Factory;
use Kreait\Firebase\ServiceAccount;
use Kreait\Firebase\Auth\User;

$apiKey = '<api key>';
$serviceAccount = ServiceAccount::discover();

$firebase = (new Factory())
    ->withServiceAccountAndApiKey($serviceAccount, $apiKey)
    ->create();

$auth = $firebase->getAuth();

try {
    // passwords must be at least six characters long
    $user = $auth->createUserWithEmailAndPassword('user@domain.tld', 'foobar');
    $updatedUser = $auth->changeUserPassword($user, 'new password');
    
    $auth->deleteUser($updatedUser);
} catch (AuthException $e) {
    echo $e->getMessage().PHP_EOL;
}
```

As a rule of thumb, use an IDE with autocompletion and let it guide you :)

## Progress

**`Firebase\Auth::`**
- [x] `getUser($uid): User` (if it doesn't exist, a new one will be created)
- [x] `createUserWithEmailAndPassword($email, $password): User`
- [x] `getUserByEmailAndPassword($email, $password): User`
- [x] `createAnonymousUser(): User`
- [x] `changeUserPassword(User $user, string $newPassword): User` 
- [x] `changeUserEmail(User $user, string $newEmail): User`
- [x] `deleteUser(User $user): void`
- [x] `sendEmailVerification(User $user): void`
- [x] Update documentation

:octocat: 