### PR TITLE
Rename interface to prevent namespace collisions

### DIFF
--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -12,7 +12,7 @@ use Kreait\Firebase\Auth\User;
 use Kreait\Firebase\Database;
 use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Exception\LogicException;
-use Kreait\Firebase\Http\Auth;
+use Kreait\Firebase\Http\AuthInterface;
 use Kreait\Firebase\Http\Auth\CustomToken;
 use Kreait\Firebase\Http\Auth\UserAuth;
 use Kreait\Firebase\Http\Middleware;
@@ -150,7 +150,7 @@ class Firebase
         return $this->tokenHandler;
     }
 
-    private function withCustomAuth(Auth $override): Firebase
+    private function withCustomAuth(AuthInterface $override): Firebase
     {
         $firebase = new self($this->serviceAccount, $this->databaseUri, $this->tokenHandler);
         $firebase->database = $this->createDatabase()->withCustomAuth($override);

--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -12,9 +12,9 @@ use Kreait\Firebase\Auth\User;
 use Kreait\Firebase\Database;
 use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Exception\LogicException;
-use Kreait\Firebase\Http\AuthInterface;
 use Kreait\Firebase\Http\Auth\CustomToken;
 use Kreait\Firebase\Http\Auth\UserAuth;
+use Kreait\Firebase\Http\AuthenticationMethod;
 use Kreait\Firebase\Http\Middleware;
 use Kreait\Firebase\ServiceAccount;
 use Psr\Http\Message\UriInterface;
@@ -150,7 +150,7 @@ class Firebase
         return $this->tokenHandler;
     }
 
-    private function withCustomAuth(AuthInterface $override): Firebase
+    private function withCustomAuth(AuthenticationMethod $override): Firebase
     {
         $firebase = new self($this->serviceAccount, $this->databaseUri, $this->tokenHandler);
         $firebase->database = $this->createDatabase()->withCustomAuth($override);

--- a/src/Firebase/Database.php
+++ b/src/Firebase/Database.php
@@ -7,7 +7,7 @@ use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Database\Reference;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Exception\OutOfRangeException;
-use Kreait\Firebase\Http\AuthInterface;
+use Kreait\Firebase\Http\AuthenticationMethod;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -45,11 +45,11 @@ class Database
     /**
      * Returns a new Database instance with the given authentication override.
      *
-     * @param AuthInterface $auth
+     * @param AuthenticationMethod $auth
      *
      * @return Database
      */
-    public function withCustomAuth(AuthInterface $auth): Database
+    public function withCustomAuth(AuthenticationMethod $auth): Database
     {
         return new self($this->uri, $this->client->withCustomAuth($auth));
     }

--- a/src/Firebase/Database.php
+++ b/src/Firebase/Database.php
@@ -7,7 +7,7 @@ use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Database\Reference;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Exception\OutOfRangeException;
-use Kreait\Firebase\Http\Auth;
+use Kreait\Firebase\Http\AuthInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -45,11 +45,11 @@ class Database
     /**
      * Returns a new Database instance with the given authentication override.
      *
-     * @param Auth $auth
+     * @param AuthInterface $auth
      *
      * @return Database
      */
-    public function withCustomAuth(Auth $auth): Database
+    public function withCustomAuth(AuthInterface $auth): Database
     {
         return new self($this->uri, $this->client->withCustomAuth($auth));
     }

--- a/src/Firebase/Database/ApiClient.php
+++ b/src/Firebase/Database/ApiClient.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
 use Kreait\Firebase\Exception\ApiException;
-use Kreait\Firebase\Http\AuthInterface;
+use Kreait\Firebase\Http\AuthenticationMethod;
 use Kreait\Firebase\Http\Middleware;
 use Kreait\Firebase\Util\JSON;
 use Psr\Http\Message\ResponseInterface;
@@ -24,7 +24,7 @@ class ApiClient
         $this->httpClient = $httpClient;
     }
 
-    public function withCustomAuth(AuthInterface $auth): ApiClient
+    public function withCustomAuth(AuthenticationMethod $auth): ApiClient
     {
         $config = $this->httpClient->getConfig();
 

--- a/src/Firebase/Database/ApiClient.php
+++ b/src/Firebase/Database/ApiClient.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
 use Kreait\Firebase\Exception\ApiException;
-use Kreait\Firebase\Http\Auth;
+use Kreait\Firebase\Http\AuthInterface;
 use Kreait\Firebase\Http\Middleware;
 use Kreait\Firebase\Util\JSON;
 use Psr\Http\Message\ResponseInterface;
@@ -24,7 +24,7 @@ class ApiClient
         $this->httpClient = $httpClient;
     }
 
-    public function withCustomAuth(Auth $auth): ApiClient
+    public function withCustomAuth(AuthInterface $auth): ApiClient
     {
         $config = $this->httpClient->getConfig();
 

--- a/src/Firebase/Http/Auth/CustomToken.php
+++ b/src/Firebase/Http/Auth/CustomToken.php
@@ -3,11 +3,11 @@
 namespace Kreait\Firebase\Http\Auth;
 
 use GuzzleHttp\Psr7;
-use Kreait\Firebase\Http\Auth;
+use Kreait\Firebase\Http\AuthInterface;
 use Kreait\Firebase\Util\JSON;
 use Psr\Http\Message\RequestInterface;
 
-final class CustomToken implements Auth
+final class CustomToken implements AuthInterface
 {
     /**
      * @var string

--- a/src/Firebase/Http/Auth/CustomToken.php
+++ b/src/Firebase/Http/Auth/CustomToken.php
@@ -3,11 +3,11 @@
 namespace Kreait\Firebase\Http\Auth;
 
 use GuzzleHttp\Psr7;
-use Kreait\Firebase\Http\AuthInterface;
+use Kreait\Firebase\Http\AuthenticationMethod;
 use Kreait\Firebase\Util\JSON;
 use Psr\Http\Message\RequestInterface;
 
-final class CustomToken implements AuthInterface
+final class CustomToken implements AuthenticationMethod
 {
     /**
      * @var string

--- a/src/Firebase/Http/Auth/UserAuth.php
+++ b/src/Firebase/Http/Auth/UserAuth.php
@@ -4,11 +4,11 @@ namespace Kreait\Firebase\Http\Auth;
 
 use GuzzleHttp\Psr7;
 use Kreait\Firebase\Auth\User;
-use Kreait\Firebase\Http\AuthInterface;
+use Kreait\Firebase\Http\AuthenticationMethod;
 use Lcobucci\JWT\Token;
 use Psr\Http\Message\RequestInterface;
 
-final class UserAuth implements AuthInterface
+final class UserAuth implements AuthenticationMethod
 {
     /**
      * @var Token

--- a/src/Firebase/Http/Auth/UserAuth.php
+++ b/src/Firebase/Http/Auth/UserAuth.php
@@ -4,11 +4,11 @@ namespace Kreait\Firebase\Http\Auth;
 
 use GuzzleHttp\Psr7;
 use Kreait\Firebase\Auth\User;
-use Kreait\Firebase\Http\Auth;
+use Kreait\Firebase\Http\AuthInterface;
 use Lcobucci\JWT\Token;
 use Psr\Http\Message\RequestInterface;
 
-final class UserAuth implements Auth
+final class UserAuth implements AuthInterface
 {
     /**
      * @var Token

--- a/src/Firebase/Http/AuthInterface.php
+++ b/src/Firebase/Http/AuthInterface.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\RequestInterface;
 /**
  * @see https://firebase.google.com/docs/auth/server/
  */
-interface Auth
+interface AuthInterface
 {
     /**
      * Returns an authenticated request from the given request.

--- a/src/Firebase/Http/AuthenticationMethod.php
+++ b/src/Firebase/Http/AuthenticationMethod.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\RequestInterface;
 /**
  * @see https://firebase.google.com/docs/auth/server/
  */
-interface AuthInterface
+interface AuthenticationMethod
 {
     /**
      * Returns an authenticated request from the given request.

--- a/src/Firebase/Http/Middleware.php
+++ b/src/Firebase/Http/Middleware.php
@@ -33,11 +33,11 @@ class Middleware
     /**
      * Adds custom authentication to a request.
      *
-     * @param \Kreait\Firebase\Http\AuthInterface $override
+     * @param \Kreait\Firebase\Http\AuthenticationMethod $override
      *
      * @return callable
      */
-    public static function overrideAuth(AuthInterface $override): callable
+    public static function overrideAuth(AuthenticationMethod $override): callable
     {
         return function (callable $handler) use ($override) {
             return function (RequestInterface $request, array $options = []) use ($handler, $override) {

--- a/src/Firebase/Http/Middleware.php
+++ b/src/Firebase/Http/Middleware.php
@@ -33,11 +33,11 @@ class Middleware
     /**
      * Adds custom authentication to a request.
      *
-     * @param \Kreait\Firebase\Http\Auth $override
+     * @param \Kreait\Firebase\Http\AuthInterface $override
      *
      * @return callable
      */
-    public static function overrideAuth(Auth $override): callable
+    public static function overrideAuth(AuthInterface $override): callable
     {
         return function (callable $handler) use ($override) {
             return function (RequestInterface $request, array $options = []) use ($handler, $override) {

--- a/tests/Firebase/Database/ApiClientTest.php
+++ b/tests/Firebase/Database/ApiClientTest.php
@@ -7,7 +7,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Exception\ApiException;
-use Kreait\Firebase\Http\Auth;
+use Kreait\Firebase\Http\AuthInterface;
 use Kreait\Tests\FirebaseTestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -37,7 +37,7 @@ class ApiClientTest extends FirebaseTestCase
 
     public function testWithCustomAuth()
     {
-        $auth = $this->createMock(Auth::class);
+        $auth = $this->createMock(AuthInterface::class);
 
         $this->http
             ->expects($this->any())

--- a/tests/Firebase/Database/ApiClientTest.php
+++ b/tests/Firebase/Database/ApiClientTest.php
@@ -7,7 +7,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Exception\ApiException;
-use Kreait\Firebase\Http\AuthInterface;
+use Kreait\Firebase\Http\AuthenticationMethod;
 use Kreait\Tests\FirebaseTestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -37,7 +37,7 @@ class ApiClientTest extends FirebaseTestCase
 
     public function testWithCustomAuth()
     {
-        $auth = $this->createMock(AuthInterface::class);
+        $auth = $this->createMock(AuthenticationMethod::class);
 
         $this->http
             ->expects($this->any())

--- a/tests/Firebase/DatabaseTest.php
+++ b/tests/Firebase/DatabaseTest.php
@@ -7,7 +7,7 @@ use Kreait\Firebase\Database;
 use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Database\Reference;
 use Kreait\Firebase\Exception\InvalidArgumentException;
-use Kreait\Firebase\Http\Auth;
+use Kreait\Firebase\Http\AuthInterface;
 use Kreait\Tests\FirebaseTestCase;
 
 class DatabaseTest extends FirebaseTestCase
@@ -37,8 +37,8 @@ class DatabaseTest extends FirebaseTestCase
 
     public function testWithCustomAuth()
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|Auth $auth */
-        $auth = $this->createMock(Auth::class);
+        /** @var \PHPUnit_Framework_MockObject_MockObject|AuthInterface $auth */
+        $auth = $this->createMock(AuthInterface::class);
 
         $this->assertInstanceOf(Database::class, $this->database->withCustomAuth($auth));
     }

--- a/tests/Firebase/DatabaseTest.php
+++ b/tests/Firebase/DatabaseTest.php
@@ -7,7 +7,7 @@ use Kreait\Firebase\Database;
 use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Database\Reference;
 use Kreait\Firebase\Exception\InvalidArgumentException;
-use Kreait\Firebase\Http\AuthInterface;
+use Kreait\Firebase\Http\AuthenticationMethod;
 use Kreait\Tests\FirebaseTestCase;
 
 class DatabaseTest extends FirebaseTestCase
@@ -37,8 +37,8 @@ class DatabaseTest extends FirebaseTestCase
 
     public function testWithCustomAuth()
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|AuthInterface $auth */
-        $auth = $this->createMock(AuthInterface::class);
+        /** @var \PHPUnit_Framework_MockObject_MockObject|AuthenticationMethod $auth */
+        $auth = $this->createMock(AuthenticationMethod::class);
 
         $this->assertInstanceOf(Database::class, $this->database->withCustomAuth($auth));
     }

--- a/tests/Firebase/Http/MiddlewareTest.php
+++ b/tests/Firebase/Http/MiddlewareTest.php
@@ -3,7 +3,7 @@
 namespace Kreait\Tests\Firebase\Http;
 
 use GuzzleHttp\Psr7;
-use Kreait\Firebase\Http\AuthInterface;
+use Kreait\Firebase\Http\AuthenticationMethod;
 use Kreait\Firebase\Http\Middleware;
 use Kreait\Tests\FirebaseTestCase;
 use Psr\Http\Message\RequestInterface;
@@ -57,7 +57,7 @@ class MiddlewareTest extends FirebaseTestCase
     {
         $authenticatedRequest = new Psr7\Request('GET', 'http://domain.tld?is_authenticated=true'); // Doesn't matter :)
 
-        $auth = $this->createMock(AuthInterface::class);
+        $auth = $this->createMock(AuthenticationMethod::class);
         $auth->expects($this->any())
             ->method('authenticateRequest')
             ->with($this->request)

--- a/tests/Firebase/Http/MiddlewareTest.php
+++ b/tests/Firebase/Http/MiddlewareTest.php
@@ -3,7 +3,7 @@
 namespace Kreait\Tests\Firebase\Http;
 
 use GuzzleHttp\Psr7;
-use Kreait\Firebase\Http\Auth;
+use Kreait\Firebase\Http\AuthInterface;
 use Kreait\Firebase\Http\Middleware;
 use Kreait\Tests\FirebaseTestCase;
 use Psr\Http\Message\RequestInterface;
@@ -57,7 +57,7 @@ class MiddlewareTest extends FirebaseTestCase
     {
         $authenticatedRequest = new Psr7\Request('GET', 'http://domain.tld?is_authenticated=true'); // Doesn't matter :)
 
-        $auth = $this->createMock(Auth::class);
+        $auth = $this->createMock(AuthInterface::class);
         $auth->expects($this->any())
             ->method('authenticateRequest')
             ->with($this->request)


### PR DESCRIPTION
This PR proposes a fix for issue #120.

For some reason, the 'Auth' interface name is colliding with another
'Auth' class or interface in code. This commit resolves that issue
by renaming the 'Auth' interface to 'AuthInterface'.