### PR TITLE
Allow valid .settings/rules PUT request

### DIFF
--- a/src/Firebase/Database/Reference/Validator.php
+++ b/src/Firebase/Database/Reference/Validator.php
@@ -20,15 +20,25 @@ class Validator
      */
     public function validateUri(UriInterface $uri)
     {
+        // Firebase has valid REST URL endpoints that contain invalid
+        // characters. For example, the PUT .settings/rules endpoint
+        // writes rules to the database. This array allows us to filter
+        // validation on those technically valid URLs.
+        $validUrls = [
+            '.settings/rules',
+        ];
+
         $path = trim($uri->getPath(), '/');
 
-        $this->validateDepth($path);
+        if (!in_array($path, $validUrls)) {
+            $this->validateDepth($path);
 
-        $keys = explode('/', $path);
+            $keys = explode('/', $path);
 
-        foreach ($keys as $key) {
-            $this->validateKeySize($key);
-            $this->validateChars($key);
+            foreach ($keys as $key) {
+                $this->validateKeySize($key);
+                $this->validateChars($key);
+            }
         }
     }
 

--- a/tests/Firebase/Database/Reference/ValidatorTest.php
+++ b/tests/Firebase/Database/Reference/ValidatorTest.php
@@ -52,4 +52,11 @@ class ValidatorTest extends FirebaseTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->validator->validateUri($uri);
     }
+
+    public function testRulesUrl()
+    {
+        $uri = $this->uri->withPath('.settings/rules');
+
+        $this->assertNull($this->validator->validateUri($uri));
+    }
 }


### PR DESCRIPTION
My attempt at solving issue #132.

Per [the docs](https://firebase.google.com/docs/database/web/structure-data), keys "cannot contain ., $, #, [, ], /, or ASCII control characters 0-31 or 127". However, [writing rules through the REST API](https://firebase.google.com/docs/database/rest/app-management) requires using the '.settings/rules' key, which contains an invalid character. This commit makes a special exception for the '.settings/rules' key.

