### PR TITLE
prevent throw array access error when `orderByChild('nested/key')`

### DIFF
--- a/src/Firebase/Database/Query/Sorter/OrderByChild.php
+++ b/src/Firebase/Database/Query/Sorter/OrderByChild.php
@@ -31,7 +31,7 @@ final class OrderByChild implements Sorter
         $childKey = $this->childKey;
         
         uasort($value, function ($a, $b) use ($childKey) {
-            return ($this->get($a, $childKey) ?? null) <=> $this->get($b, $childKey) ?? null;
+            return ($this->accessToArrayPath($a, $childKey) ?? null) <=> $this->accessToArrayPath($b, $childKey) ?? null;
         });
         
         return $value;
@@ -53,30 +53,18 @@ final class OrderByChild implements Sorter
      * @return array|mixed|null
      *
      */
-    function get($collection = [], $key = '', $default = null)
+    function accessToArrayPath($collection = [], $key = '', $default = null)
     {
         if (is_null($key)) {
             return $collection;
         }
 
-        if (!is_object($collection) && isset($collection[$key])) {
-            return $collection[$key];
-        }
-
         foreach (explode('/', $key) as $segment) {
-            if (is_object($collection)) {
-                if (!isset($collection->{$segment})) {
-                    return $default instanceof \Closure ? $default() : $default;
-                } else {
-                    $collection = $collection->{$segment};
-                }
-            } else {
-                if (!isset($collection[$segment])) {
-                    return $default instanceof \Closure ? $default() : $default;
-                } else {
-                    $collection = $collection[$segment];
-                }
+            if (!isset($collection[$segment])) {
+                return $default instanceof \Closure ? $default() : $default;
             }
+
+            $collection = $collection[$segment];
         }
 
         return $collection;

--- a/src/Firebase/Database/Query/Sorter/OrderByChild.php
+++ b/src/Firebase/Database/Query/Sorter/OrderByChild.php
@@ -27,13 +27,58 @@ final class OrderByChild implements Sorter
         if (!is_array($value)) {
             return $value;
         }
-
+        
         $childKey = $this->childKey;
-
+        
         uasort($value, function ($a, $b) use ($childKey) {
-            return ($a[$childKey] ?? null) <=> $b[$childKey] ?? null;
+            return ($this->get($a, $childKey) ?? null) <=> $this->get($b, $childKey) ?? null;
         });
-
+        
         return $value;
+    }
+
+    /**
+     * Function taken from Mohamed Meabed repo:
+     * https://github.com/tajawal/lodash-php/blob/master/src/collections/get.php
+     * 
+     * Get item of an array by index , aceepting nested index
+     *
+     ** __::get(['foo' => ['bar' => 'ter']], 'foo/bar');
+     ** // → 'ter'
+     *
+     * @param array  $collection array of values
+     * @param string $key        key or index
+     * @param null   $default    default value to return if index not exist
+     *
+     * @return array|mixed|null
+     *
+     */
+    function get($collection = [], $key = '', $default = null)
+    {
+        if (is_null($key)) {
+            return $collection;
+        }
+
+        if (!is_object($collection) && isset($collection[$key])) {
+            return $collection[$key];
+        }
+
+        foreach (explode('/', $key) as $segment) {
+            if (is_object($collection)) {
+                if (!isset($collection->{$segment})) {
+                    return $default instanceof \Closure ? $default() : $default;
+                } else {
+                    $collection = $collection->{$segment};
+                }
+            } else {
+                if (!isset($collection[$segment])) {
+                    return $default instanceof \Closure ? $default() : $default;
+                } else {
+                    $collection = $collection[$segment];
+                }
+            }
+        }
+
+        return $collection;
     }
 }


### PR DESCRIPTION
This PR prevent throw array access errors when use nested Firebase paths on `orderByChild`. Look at the next query example:

```php
$firebase->getReference('users')
  ->orderByChild('profile/email') // nested Firebase path
  ->startAt('john@')
  ->getValue();
```

The schema:

```json
"users": {
  "a1": {
    "profile": {
      "email": "john@doe.com"
     }
  }
}
```
Before this throwed `[ErrorException] Undefined index: profile/email`.

Now this query doesn't throw exceptions.