### PR TITLE
Get and Set Firebase Rules

### DIFF
--- a/docs/realtime-database.rst
+++ b/docs/realtime-database.rst
@@ -378,6 +378,34 @@ includes the sent request and the received response object:
     }
 
 
+*****
+Rules
+*****
+
+Manage Firebase Realtime Database Rules through the following examples. 
+
+Detailed information can be found on
+`the official Firebase documentation page for Rules management via REST <https://firebase.google.com/docs/database/rest/app-management>`_
+
+Update Rules
+=============
+
+.. code-block:: php
+
+        $this->firebase->getDatabase()->setRules([
+            'rules' => [
+                '.read' => true,
+                '.write' => false
+            ]
+        ]);
+
+Retrieve Rules
+=============
+
+.. code-block:: php
+
+        $this->firebase->getDatabase()->getRules();
+
 .. rubric:: Footnotes
 
 .. [#f1] This example and its description is the same as in the official documentation:

--- a/docs/realtime-database.rst
+++ b/docs/realtime-database.rst
@@ -392,7 +392,7 @@ Update Rules
 
 .. code-block:: php
 
-        $this->firebase->getDatabase()->setRules([
+        $database->setRules([
             'rules' => [
                 '.read' => true,
                 '.write' => false
@@ -404,7 +404,7 @@ Retrieve Rules
 
 .. code-block:: php
 
-        $this->firebase->getDatabase()->getRules();
+        $database->getRules();
 
 .. rubric:: Footnotes
 

--- a/src/Firebase/Database.php
+++ b/src/Firebase/Database.php
@@ -103,4 +103,40 @@ class Database
 
         return $this->getReference($uri->getPath());
     }
+
+    /**
+     * Retrieve Firebase Database Rules.
+     *
+     * @see https://firebase.google.com/docs/database/rest/app-management#retrieving-firebase-realtime-database-rules
+     *
+     * @return array
+     */
+    public function getRules(): array
+    {
+        $rules = $this->client->get($this->uri->withPath('.settings/rules'));
+
+        return $rules ? $rules : [];
+    }
+
+    /**
+     * Update Firebase Database Rules.
+     *
+     * @see https://firebase.google.com/docs/database/rest/app-management#updating-firebase-realtime-database-rules
+     *
+     * @param array $rules
+     *
+     * @throws InvalidArgumentException If rules are invalid
+     *
+     * @return Database
+     */
+    public function setRules(array $rules): Database
+    {
+        try {
+            $this->client->set($this->uri->withPath('.settings/rules'), $rules);
+        } catch (InvalidArgumentException $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode());
+        }
+
+        return $this;
+    }
 }

--- a/tests/Firebase/DatabaseTest.php
+++ b/tests/Firebase/DatabaseTest.php
@@ -76,4 +76,22 @@ class DatabaseTest extends FirebaseTestCase
 
         $this->database->getReferenceFromUrl('http://non-matching.tld');
     }
+
+    public function testGetRules()
+    {
+        $this->apiClient->expects($this->once())
+            ->method('get')
+            ->with($this->uri->withPath('.settings/rules'));
+
+        $this->assertEquals($this->database->getRules(), []);
+    }
+
+    public function testSetRules()
+    {
+        $this->apiClient->expects($this->once())
+            ->method('set')
+            ->with($this->uri->withPath('.settings/rules'));
+
+        $this->assertEquals($this->database->setRules([]), $this->database);
+    }
 }


### PR DESCRIPTION
Get and Set Firebase Rules via the REST API, as noted in this documentation: https://firebase.google.com/docs/database/rest/app-management

This is a proposed fix for Issue #132.