### PR TITLE
Don't fetch user after deleting

### DIFF
--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -132,11 +132,9 @@ class Auth
         $this->client->disableUser($uid = $this->uid($userOrUid));
     }
 
-    public function deleteUser($userOrUid): User
+    public function deleteUser($userOrUid)
     {
         $this->client->deleteUser($uid = $this->uid($userOrUid));
-
-        return $this->getUser($uid);
     }
 
     /**


### PR DESCRIPTION
Otherwrise Firebase creates an empty user account with the same uid