### PR TITLE
Add support for Firebase RemoteConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://github.com/jeromegamez/firebase-php-examples
 | [ID Token Verification](https://firebase.google.com/docs/auth/admin/verify-id-tokens)	| ✅ | ✅ | ✅ | ✅ | ✅ |
 | [Realtime Database API](https://firebase.google.com/docs/database/admin/start) | ✅* | ✅ | ✅ | ✅* | ✅ |
 | [User Management API](https://firebase.google.com/docs/auth/admin/manage-users) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Remote Config](https://firebase.google.com/docs/remote-config/) | ✅ | | | | |
 | [Cloud Messaging API](https://firebase.google.com/docs/cloud-messaging/admin/) |  | ✅ | ✅ | ✅ | ✅ |				
 | [Cloud Storage API](https://firebase.google.com/docs/storage/admin/start) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [Cloud Firestore API](https://firebase.google.com/docs/firestore/) | | ✅ | ✅ | ✅ | ✅ |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,4 +39,5 @@ User Guide
     authentication
     user-management
     storage
+    remote-config
     troubleshooting

--- a/docs/remote-config.rst
+++ b/docs/remote-config.rst
@@ -1,0 +1,117 @@
+#############
+Remote Config
+#############
+
+Change the behavior and appearance of your app without publishing an app update.
+
+Firebase Remote Config is a cloud service that lets you change the behavior and appearance of your app without
+requiring users to download an app update. When using Remote Config, you create in-app default values that
+control the behavior and appearance of your app.
+
+Before you start, please read about Firebase Remote Config in the official documentation:
+
+- `Firebase Remote Config <https://firebase.google.com/docs/remote-config/>`_
+
+.. note::
+    The implementation in this library is in its very early stages and has been created at the
+    announcement day of the Remote Config REST API (see the
+    `Announcement post in the Firebase Blog <https://firebase.googleblog.com/2018/03/announcing-remote-config-rest-api.html>`_). It
+    currently only supports getting and setting the raw configuration, and will be extended over time.
+
+****************
+Before you begin
+****************
+
+For Firebase projects created before the March 7, 2018 release of the Remote Config REST API, you must enable the API in the Google APIs console.
+
+1. Open the `Firebase Remote Config API page <https://console.developers.google.com/apis/api/firebaseremoteconfig.googleapis.com/overview?project=_>`_ in the Google APIs console.
+2. When prompted, select your Firebase project. (Every Firebase project has a corresponding project in the Google APIs console.)
+3. Click Enable on the Firebase Remote Config API page.
+
+You can work with your Firebase application's Remote Config by invoking the ``getRemoteConfig()``
+method of your Firebase instance:
+
+.. code-block:: php
+
+    use Kreait\Firebase;
+
+    $firebase = (new Firebase\Factory())->create();
+    $remoteConfig = $firebase->getRemoteConfig();
+
+*********************
+Get the Remote Config
+*********************
+
+.. code-block:: php
+
+    $template = $remoteConfig->getTemplate();
+    echo json_encode($template, JSON_PRETTY_PRINT);
+
+**************************
+Create a new Remote Config
+**************************
+
+.. code-block:: php
+
+    use Kreait\Firebase\RemoteConfig;
+
+    $template = RemoteConfig\Template::new();
+
+***************
+Add a condition
+***************
+
+.. code-block:: php
+
+    use Kreait\Firebase\RemoteConfig;
+
+    $germanLanguageCondition = RemoteConfig\Condition::named('lang_german')
+        ->withExpression("device.language in ['de', 'de_AT', 'de_CH']")
+        ->withTagColor(TagColor::ORANGE); // The TagColor is optional
+
+    $template = $template->withCondition($germanLanguageCondition);
+
+***************
+Add a parameter
+***************
+
+.. code-block:: php
+
+    use Kreait\Firebase\RemoteConfig;
+
+    $welcomeMessageParameter = Parameter::named('welcome_message')
+            ->withDefaultValue('Welcome!')
+            ->withDescription('This is a welcome message') // optional
+    ;
+
+******************
+Conditional values
+******************
+
+.. code-block:: php
+
+    use Kreait\Firebase\RemoteConfig;
+
+    $germanLanguageCondition = RemoteConfig\Condition::named('lang_german')
+        ->withExpression("device.language in ['de', 'de_AT', 'de_CH']");
+
+    $germanWelcomeMessage = RemoteConfig\ConditionalValue::basedOn($germanLanguageCondition, 'Willkommen!');
+
+    $welcomeMessageParameter = Parameter::named('welcome_message')
+            ->withDefaultValue('Welcome!')
+            ->withConditionalValue($germanWelcomeMessage);
+
+    $template = $template
+        ->withCondition($germanLanguageCondition)
+        ->withParameter($welcomeMessageParameter);
+
+.. note::
+    When you use a conditional value, make sure to add the corresponding condition to the template first.
+
+*************************
+Publish the Remote Config
+*************************
+
+.. code-block:: php
+
+    $remoteConfig->publishTemplate($template);

--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -4,6 +4,7 @@ namespace Kreait;
 
 use Kreait\Firebase\Auth;
 use Kreait\Firebase\Database;
+use Kreait\Firebase\RemoteConfig;
 use Kreait\Firebase\Storage;
 
 class Firebase
@@ -23,11 +24,17 @@ class Firebase
      */
     private $storage;
 
-    public function __construct(Database $database, Auth $auth, Storage $storage)
+    /**
+     * @var RemoteConfig
+     */
+    private $remoteConfig;
+
+    public function __construct(Database $database, Auth $auth, Storage $storage, RemoteConfig $remoteConfig)
     {
         $this->database = $database;
         $this->auth = $auth;
         $this->storage = $storage;
+        $this->remoteConfig = $remoteConfig;
     }
 
     public function getDatabase(): Database
@@ -43,5 +50,10 @@ class Firebase
     public function getStorage(): Storage
     {
         return $this->storage;
+    }
+
+    public function getRemoteConfig(): RemoteConfig
+    {
+        return $this->remoteConfig;
     }
 }

--- a/src/Firebase/Exception/RemoteConfig/OperationAborted.php
+++ b/src/Firebase/Exception/RemoteConfig/OperationAborted.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Exception\RemoteConfig;
+
+use Kreait\Firebase\Exception\RemoteConfigException;
+use Throwable;
+
+class OperationAborted extends RemoteConfigException
+{
+    const IDENTIFER = 'ABORTED';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        $message = 'Operation aborted. The reason is most probably that the remote config template has been updated remotely since you last fetched it.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/RemoteConfig/PermissionDenied.php
+++ b/src/Firebase/Exception/RemoteConfig/PermissionDenied.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Exception\RemoteConfig;
+
+use Kreait\Firebase\Exception\RemoteConfigException;
+use Throwable;
+
+class PermissionDenied extends RemoteConfigException
+{
+    const IDENTIFER = 'PERMISSION_DENIED';
+
+    public function __construct($code = 0, Throwable $previous = null)
+    {
+        parent::__construct('Permission denied', $code, $previous);
+    }
+}

--- a/src/Firebase/Exception/RemoteConfigException.php
+++ b/src/Firebase/Exception/RemoteConfigException.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Kreait\Firebase\Exception;
+
+use GuzzleHttp\Exception\RequestException;
+use Kreait\Firebase\Exception\RemoteConfig\OperationAborted;
+use Kreait\Firebase\Exception\RemoteConfig\PermissionDenied;
+use Kreait\Firebase\Util\JSON;
+
+class RemoteConfigException extends \RuntimeException implements FirebaseException
+{
+    public static $errors = [
+        PermissionDenied::IDENTIFER => PermissionDenied::class,
+        OperationAborted::IDENTIFER => OperationAborted::class,
+    ];
+
+    /**
+     * @param RequestException $e
+     *
+     * @return self
+     */
+    public static function fromRequestException(RequestException $e): self
+    {
+        $message = $e->getMessage();
+
+        /* @noinspection NullPointerExceptionInspection */
+        if ($e->getResponse() && JSON::isValid($responseBody = (string) $e->getResponse()->getBody())) {
+            /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
+            $errors = JSON::decode($responseBody, true);
+            $message = $errors['error']['message'] ?? $message;
+        }
+
+        $candidates = array_filter(array_map(function ($key, $class) use ($message, $e) {
+            return false !== stripos($message, $key)
+                ? new $class($e->getCode(), $e)
+                : null;
+        }, array_keys(self::$errors), self::$errors));
+
+        $fallback = new static($message, $e->getCode(), $e);
+
+        return array_shift($candidates) ?? $fallback;
+    }
+}

--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -97,8 +97,9 @@ class Factory
         $database = $this->createDatabase();
         $auth = $this->createAuth();
         $storage = $this->createStorage();
+        $remoteConfig = $this->createRemoteConfig();
 
-        return new Firebase($database, $auth, $storage);
+        return new Firebase($database, $auth, $storage, $remoteConfig);
     }
 
     private function getServiceAccountDiscoverer(): Discoverer
@@ -174,6 +175,15 @@ class Factory
         return new Database($this->getDatabaseUri(), new Database\ApiClient($http));
     }
 
+    private function createRemoteConfig()
+    {
+        $http = $this->createApiClient($this->getServiceAccount(), [
+            'base_uri' => 'https://firebaseremoteconfig.googleapis.com/v1/projects/'.$this->getServiceAccount()->getProjectId().'/remoteConfig',
+        ]);
+
+        return new RemoteConfig(new RemoteConfig\ApiClient($http));
+    }
+
     private function createApiClient(ServiceAccount $serviceAccount, array $config = []): Client
     {
         $googleAuthTokenMiddleware = $this->createGoogleAuthTokenMiddleware($serviceAccount);
@@ -194,6 +204,7 @@ class Factory
         $scopes = [
             'https://www.googleapis.com/auth/cloud-platform',
             'https://www.googleapis.com/auth/firebase',
+            'https://www.googleapis.com/auth/firebase.remoteconfig',
             'https://www.googleapis.com/auth/userinfo.email',
         ];
 

--- a/src/Firebase/RemoteConfig.php
+++ b/src/Firebase/RemoteConfig.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase;
+
+use Kreait\Firebase\RemoteConfig\ApiClient;
+use Kreait\Firebase\RemoteConfig\Template;
+
+/**
+ * The Firebase Remote Config.
+ *
+ * @see https://firebase.google.com/docs/remote-config/use-config-rest
+ * @see https://firebase.google.com/docs/remote-config/rest-reference
+ */
+class RemoteConfig
+{
+    /**
+     * @var ApiClient
+     */
+    private $client;
+
+    public function __construct(ApiClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function get(): Template
+    {
+        return Template::fromResponse($this->client->getTemplate());
+    }
+
+    public function publish(Template $template): string
+    {
+        $response = $this->client->publishTemplate($template);
+
+        $etag = $response->getHeader('ETag');
+
+        return array_shift($etag);
+    }
+}

--- a/src/Firebase/RemoteConfig/ApiClient.php
+++ b/src/Firebase/RemoteConfig/ApiClient.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Kreait\Firebase\RemoteConfig;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use Kreait\Firebase\Exception\RemoteConfigException;
+use Kreait\Firebase\Util\JSON;
+use Psr\Http\Message\ResponseInterface;
+
+class ApiClient
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    public function getTemplate(): ResponseInterface
+    {
+        return $this->request('GET', 'remoteConfig');
+    }
+
+    public function publishTemplate(Template $template): ResponseInterface
+    {
+        return $this->request('PUT', 'remoteConfig', [
+            'headers' => [
+                'Content-Type' => 'application/json; UTF-8',
+                'If-Match' => $template->getEtag(),
+            ],
+            'body' => JSON::encode($template),
+        ]);
+    }
+
+    private function request($method, $uri, array $options = [])
+    {
+        $options = array_merge($options, [
+            'decode_content' => 'gzip', // sets content-type and deflates response body
+        ]);
+
+        try {
+            return $this->client->request($method, $uri, $options);
+        } catch (RequestException $e) {
+            throw RemoteConfigException::fromRequestException($e);
+        } catch (\Throwable $e) {
+            throw new RemoteConfigException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/Firebase/RemoteConfig/Condition.php
+++ b/src/Firebase/RemoteConfig/Condition.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+class Condition implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $expression;
+
+    /**
+     * @var TagColor|null
+     */
+    private $tagColor;
+
+    private function __construct(string $name, string $expression, TagColor $tagColor = null)
+    {
+        $this->name = $name;
+        $this->expression = $expression;
+        $this->tagColor = $tagColor;
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['name'],
+            $data['expression'],
+            isset($data['tagColor']) ? new TagColor($data['tagColor']) : null
+        );
+    }
+
+    public static function named(string $name): self
+    {
+        return new self($name, 'false', null);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function withExpression(string $expression): self
+    {
+        $condition = clone $this;
+        $condition->expression = $expression;
+
+        return $condition;
+    }
+
+    public function withTagColor($tagColor): self
+    {
+        $tagColor = $tagColor instanceof TagColor ? $tagColor : new TagColor($tagColor);
+
+        $condition = clone $this;
+        $condition->tagColor = $tagColor;
+
+        return $condition;
+    }
+
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'name' => $this->name,
+            'expression' => $this->expression,
+            'tagColor' => $this->tagColor ? $this->tagColor->value() : null,
+        ], function ($value) {
+            return null !== $value;
+        });
+    }
+}

--- a/src/Firebase/RemoteConfig/ConditionalValue.php
+++ b/src/Firebase/RemoteConfig/ConditionalValue.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+class ConditionalValue implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $conditionName;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(string $conditionName, string $value)
+    {
+        $this->conditionName = $conditionName;
+        $this->value = $value;
+    }
+
+    public function conditionName(): string
+    {
+        return $this->conditionName;
+    }
+
+    public static function basedOn(Condition $condition): self
+    {
+        return new self($condition->name(), '');
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function withValue(string $value): self
+    {
+        $conditionalValue = clone $this;
+        $conditionalValue->value = $value;
+
+        return $conditionalValue;
+    }
+
+    public function jsonSerialize()
+    {
+        return ['value' => $this->value];
+    }
+}

--- a/src/Firebase/RemoteConfig/DefaultValue.php
+++ b/src/Firebase/RemoteConfig/DefaultValue.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+class DefaultValue implements \JsonSerializable
+{
+    const IN_APP_DEFAULT_VALUE = true;
+
+    /**
+     * @var string|bool
+     */
+    private $value;
+
+    private function __construct($value)
+    {
+        $this->value = \is_string($value) ? $value : true;
+    }
+
+    public static function none(): self
+    {
+        return new self(self::IN_APP_DEFAULT_VALUE);
+    }
+
+    public static function with(string $value): self
+    {
+        return new self($value);
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['value'] ?? $data['useInAppDefault'] ?? null);
+    }
+
+    public function jsonSerialize()
+    {
+        $key = true === $this->value ? 'useInAppDefault' : 'value';
+
+        return [$key => $this->value];
+    }
+}

--- a/src/Firebase/RemoteConfig/Parameter.php
+++ b/src/Firebase/RemoteConfig/Parameter.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+use Kreait\Firebase\Exception\InvalidArgumentException;
+
+class Parameter implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $description = '';
+
+    /**
+     * @var DefaultValue
+     */
+    private $defaultValue;
+
+    /**
+     * @var ConditionalValue[]
+     */
+    private $conditionalValues = [];
+
+    public static function named(string $name, $defaultValue = null): self
+    {
+        if (null === $defaultValue) {
+            $defaultValue = DefaultValue::none();
+        } elseif (\is_string($defaultValue)) {
+            $defaultValue = DefaultValue::with($defaultValue);
+        } else {
+            throw new InvalidArgumentException('The default value for a remote config parameter must be a string or NULL to use the in-app default.');
+        }
+
+        $parameter = new self();
+        $parameter->name = $name;
+        $parameter->defaultValue = $defaultValue;
+
+        return $parameter;
+    }
+
+    /**
+     * @return string
+     */
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function withDescription(string $description): self
+    {
+        $parameter = clone $this;
+        $parameter->description = $description;
+
+        return $parameter;
+    }
+
+    public function withDefaultValue($defaultValue): self
+    {
+        $defaultValue = $defaultValue instanceof DefaultValue ? $defaultValue : DefaultValue::with($defaultValue);
+
+        $parameter = clone $this;
+        $parameter->defaultValue = $defaultValue;
+
+        return $parameter;
+    }
+
+    public function defaultValue(): DefaultValue
+    {
+        return $this->defaultValue;
+    }
+
+    public function withConditionalValue(ConditionalValue $conditionalValue): self
+    {
+        $parameter = clone $this;
+        $parameter->conditionalValues[] = $conditionalValue;
+
+        return $parameter;
+    }
+
+    /**
+     * @return ConditionalValue[]
+     */
+    public function conditionalValues(): array
+    {
+        return $this->conditionalValues;
+    }
+
+    public static function fromArray(array $data): self
+    {
+        reset($data);
+        $parameterData = current($data);
+
+        $parameter = new self();
+        $parameter->name = key($data);
+        $parameter->defaultValue = DefaultValue::fromArray($parameterData['defaultValue'] ?? []);
+
+        foreach ((array) ($parameterData['conditionalValues'] ?? []) as $key => $conditionalValueData) {
+            $parameter = $parameter->withConditionalValue(new ConditionalValue($key, $conditionalValueData['value']));
+        }
+
+        if (\is_string($parameterData['description'] ?? null)) {
+            $parameter->description = $parameterData['description'];
+        }
+
+        return $parameter;
+    }
+
+    public function jsonSerialize()
+    {
+        $conditionalValues = [];
+        foreach ($this->conditionalValues() as $conditionalValue) {
+            $conditionalValues[$conditionalValue->conditionName()] = $conditionalValue->jsonSerialize();
+        }
+
+        return array_filter([
+            'defaultValue' => $this->defaultValue,
+            'conditionalValues' => $conditionalValues,
+            'description' => $this->description,
+        ]);
+    }
+}

--- a/src/Firebase/RemoteConfig/TagColor.php
+++ b/src/Firebase/RemoteConfig/TagColor.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+use Kreait\Firebase\Exception\InvalidArgumentException;
+
+class TagColor
+{
+    const BLUE = 'BLUE';
+    const BROWN = 'BROWN';
+    const CYAN = 'CYAN';
+    const DEEP_ORANGE = 'DEEP_ORANGE';
+    const GREEN = 'GREEN';
+    const INDIGO = 'INDIGO';
+    const LIME = 'LIME';
+    const ORANGE = 'ORANGE';
+    const PINK = 'PINK';
+    const PURPLE = 'PURPLE';
+    const TEAL = 'TEAL';
+
+    const VALID_COLORS = [
+        self::BLUE, self::BROWN, self::CYAN, self::DEEP_ORANGE, self::GREEN, self::INDIGO, self::LIME,
+        self::ORANGE, self::PINK, self::PURPLE, self::TEAL,
+    ];
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $value = strtoupper($value);
+
+        if (!\in_array($value, self::VALID_COLORS)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid tag color "%s". Supported colors are "%s".',
+                    $value, implode('", "', self::VALID_COLORS)
+            ));
+        }
+
+        $this->value = $value;
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/src/Firebase/RemoteConfig/Template.php
+++ b/src/Firebase/RemoteConfig/Template.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+use Kreait\Firebase\Exception\InvalidArgumentException;
+use Kreait\Firebase\Util\JSON;
+use Psr\Http\Message\ResponseInterface;
+
+class Template implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $etag = '*';
+
+    /**
+     * @var Parameter[]
+     */
+    private $parameters = [];
+
+    /**
+     * @var Condition[]
+     */
+    private $conditions = [];
+
+    public static function new(): self
+    {
+        $template = new self();
+        $template->etag = '*';
+        $template->parameters = [];
+
+        return $template;
+    }
+
+    public static function fromResponse(ResponseInterface $response): self
+    {
+        $etagHeader = $response->getHeader('ETag');
+        $etag = array_shift($etagHeader) ?? '*';
+        $data = JSON::decode((string) $response->getBody(), true);
+
+        return self::fromArray($data, $etag);
+    }
+
+    public static function fromArray(array $data, string $etag = '*'): self
+    {
+        $template = new self();
+        $template->etag = $etag;
+
+        foreach ((array) ($data['conditions'] ?? []) as $conditionData) {
+            $template->conditions[] = Condition::fromArray($conditionData);
+        }
+
+        foreach ((array) ($data['parameters'] ?? []) as $name => $parameterData) {
+            $template->parameters[$name] = Parameter::fromArray([$name => $parameterData]);
+        }
+
+        return $template;
+    }
+
+    public function getEtag(): string
+    {
+        return $this->etag;
+    }
+
+    public function withParameter(Parameter $parameter)
+    {
+        $this->assertThatAllConditionalValuesAreValid($parameter);
+
+        $template = clone $this;
+        $template->parameters[$parameter->name()] = $parameter;
+
+        return $template;
+    }
+
+    public function withCondition(Condition $condition)
+    {
+        $template = clone $this;
+        $template->conditions[$condition->name()] = $condition;
+
+        return $template;
+    }
+
+    private function assertThatAllConditionalValuesAreValid(Parameter $parameter): void
+    {
+        $allValid = array_reduce($parameter->conditionalValues(), function (bool $result, ConditionalValue $conditionalValue) {
+            return $result ?: $this->conditionExists($conditionalValue->conditionName());
+        }, false);
+
+        if (!$allValid && \count($parameter->conditionalValues())) {
+            throw new InvalidArgumentException('Not all given conditional values refer to an existing condition.');
+        }
+    }
+
+    private function conditionExists(string $conditionName): bool
+    {
+        return array_key_exists($conditionName, $this->conditions);
+    }
+
+    public function jsonSerialize()
+    {
+        $result = [
+            'conditions' => array_values($this->conditions),
+            'parameters' => $this->parameters,
+        ];
+
+        return array_filter($result);
+    }
+}

--- a/src/Firebase/Util/JSON.php
+++ b/src/Firebase/Util/JSON.php
@@ -76,4 +76,9 @@ class JSON
             return false;
         }
     }
+
+    public static function prettyPrint($value): string
+    {
+        return self::encode($value, JSON_PRETTY_PRINT);
+    }
 }

--- a/tests/Integration/RemoteConfigTest.php
+++ b/tests/Integration/RemoteConfigTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Integration;
+
+use Kreait\Firebase\Exception\RemoteConfig\OperationAborted;
+use Kreait\Firebase\RemoteConfig;
+use Kreait\Firebase\RemoteConfig\Condition;
+use Kreait\Firebase\RemoteConfig\ConditionalValue;
+use Kreait\Firebase\RemoteConfig\Parameter;
+use Kreait\Firebase\RemoteConfig\TagColor;
+use Kreait\Firebase\RemoteConfig\Template;
+use Kreait\Firebase\Tests\IntegrationTestCase;
+
+class RemoteConfigTest extends IntegrationTestCase
+{
+    private $template = <<<CONFIG
+{
+    "conditions": [
+        {
+            "name": "lang_german",
+            "expression": "device.language in ['de', 'de_AT', 'de_CH']",
+            "tagColor": "ORANGE"
+        },
+        {
+            "name": "lang_french",
+            "expression": "device.language in ['fr', 'fr_CA', 'fr_CH']",
+            "tagColor": "GREEN"
+        }
+    ],
+    "parameters": {
+        "welcome_message": {
+            "defaultValue": {
+                "value": "Welcome!"
+            },
+            "conditionalValues": {
+                "lang_german": {
+                    "value": "Willkommen!"
+                },
+                "lang_french": {
+                    "value": "Bienvenu!"
+                }
+            },
+            "description": "This is a welcome message"
+        }
+    }
+}
+CONFIG;
+
+    /**
+     * @var RemoteConfig
+     */
+    private $remoteConfig;
+
+    protected function setUp()
+    {
+        $this->remoteConfig = self::$firebase->getRemoteConfig();
+    }
+
+    public function testPublishAndGet()
+    {
+        $template = RemoteConfig\Template::fromArray(\json_decode($this->template, true));
+
+        $etag = $this->remoteConfig->publish($template);
+
+        $check = $this->remoteConfig->get();
+
+        $this->assertSame($etag, $check->getEtag());
+    }
+
+    public function testPublishOutdatedConfig()
+    {
+        $initial = RemoteConfig\Template::fromArray(\json_decode($this->template, true));
+
+        $initialEtag = $this->remoteConfig->publish($initial);
+
+        $published = $this->remoteConfig->get();
+
+        $this->assertSame($initialEtag, $published->getEtag());
+
+        $this->remoteConfig->publish($published);
+
+        $this->expectException(OperationAborted::class);
+        $this->remoteConfig->publish($published);
+    }
+
+    public function testWithFluidConfiguration()
+    {
+        $germanLanguageCondition = Condition::named('lang_german')
+            ->withExpression("device.language in ['de', 'de_AT', 'de_CH']")
+            ->withTagColor(TagColor::ORANGE);
+
+        $frenchLanguageCondition = Condition::fromArray([
+            'name' => 'lang_french',
+            'expression' => "device.language in ['fr', 'fr_CA', 'fr_CH']",
+            'tagColor' => TagColor::GREEN,
+        ]);
+
+        $germanWelcomeMessage = ConditionalValue::basedOn($germanLanguageCondition)->withValue('Willkommen!');
+        $frenchWelcomeMessage = new ConditionalValue('lang_french', 'Bienvenu!');
+
+        $welcomeMessageParameter = Parameter::named('welcome_message')
+            ->withDefaultValue('Welcome!')
+            ->withDescription('This is a welcome message')
+            ->withConditionalValue($germanWelcomeMessage)
+            ->withConditionalValue($frenchWelcomeMessage)
+        ;
+
+        $template = Template::new()
+            ->withCondition($germanLanguageCondition)
+            ->withCondition($frenchLanguageCondition)
+            ->withParameter($welcomeMessageParameter)
+        ;
+
+        $this->remoteConfig->publish($template);
+
+        $this->assertTrue($noExceptionHasBeenThrown = true);
+    }
+}

--- a/tests/Unit/RemoteConfig/ApiClientTest.php
+++ b/tests/Unit/RemoteConfig/ApiClientTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use Kreait\Firebase\Exception\RemoteConfigException;
+use Kreait\Firebase\RemoteConfig\ApiClient;
+use Kreait\Firebase\Tests\UnitTestCase;
+use Psr\Http\Message\RequestInterface;
+
+class ApiClientTest extends UnitTestCase
+{
+    /**
+     * @var ClientInterface
+     */
+    private $http;
+
+    /**
+     * @var ApiClient
+     */
+    private $client;
+
+    protected function setUp()
+    {
+        $this->http = $this->createMock(ClientInterface::class);
+        $this->client = new ApiClient($this->http);
+    }
+
+    public function testCatchRequestException()
+    {
+        $request = $this->prophesize(RequestInterface::class);
+
+        $this->http
+            ->expects($this->once())
+            ->method('request')
+            ->willThrowException(new RequestException('Foo', $request->reveal()));
+
+        $this->expectException(RemoteConfigException::class);
+        $this->client->getTemplate();
+    }
+
+    public function testCatchThrowable()
+    {
+        $this->http
+            ->expects($this->once())
+            ->method('request')
+            ->willThrowException(new \Exception());
+
+        $this->expectException(RemoteConfigException::class);
+        $this->client->getTemplate();
+    }
+}

--- a/tests/Unit/RemoteConfig/ConditionTest.php
+++ b/tests/Unit/RemoteConfig/ConditionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
+
+use Kreait\Firebase\RemoteConfig\Condition;
+use Kreait\Firebase\RemoteConfig\TagColor;
+use Kreait\Firebase\Tests\UnitTestCase;
+
+class ConditionTest extends UnitTestCase
+{
+    /**
+     * @dataProvider valueProvider
+     */
+    public function testCreateCondition(string $name, string $expression = null, $tagColor = null)
+    {
+        $condition = Condition::named($name);
+
+        if ($expression) {
+            $condition = $condition->withExpression($expression);
+        }
+
+        if ($tagColor) {
+            $condition = $condition->withTagColor($tagColor);
+        }
+
+        $this->assertSame($name, $condition->name());
+        $expected = [
+            'name' => $name,
+            'expression' => $expression ?: 'false',
+            'tagColor' => $tagColor ? (string) $tagColor : null,
+        ];
+
+        $this->assertEquals(array_filter($expected), $condition->jsonSerialize());
+        $this->assertEquals($condition, Condition::fromArray($expected));
+    }
+
+    public function valueProvider()
+    {
+        return [
+            ['name', 'expression', TagColor::GREEN],
+            ['name', 'expression', new TagColor(TagColor::ORANGE)],
+            ['name', 'expression', null],
+            ['name', null, null],
+        ];
+    }
+}

--- a/tests/Unit/RemoteConfig/ConditionalValueTest.php
+++ b/tests/Unit/RemoteConfig/ConditionalValueTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
+
+use Kreait\Firebase\RemoteConfig\Condition;
+use Kreait\Firebase\RemoteConfig\ConditionalValue;
+use Kreait\Firebase\Tests\UnitTestCase;
+
+class ConditionalValueTest extends UnitTestCase
+{
+    public function testCreate()
+    {
+        $condition = Condition::named('my_condition');
+
+        $conditionalValue = ConditionalValue::basedOn($condition)
+            ->withValue('foo');
+
+        $this->assertSame($condition->name(), $conditionalValue->conditionName());
+        $this->assertSame('foo', $conditionalValue->value());
+        $this->assertEquals(['value' => 'foo'], $conditionalValue->jsonSerialize());
+    }
+}

--- a/tests/Unit/RemoteConfig/DefaultValueTest.php
+++ b/tests/Unit/RemoteConfig/DefaultValueTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
+
+use Kreait\Firebase\RemoteConfig\DefaultValue;
+use PHPUnit\Framework\TestCase;
+
+class DefaultValueTest extends TestCase
+{
+    public function testCreateInAppDefaultValue()
+    {
+        $defaultValue = DefaultValue::none();
+
+        $this->assertEquals(['useInAppDefault' => true], $defaultValue->jsonSerialize());
+    }
+
+    public function testCreate()
+    {
+        $defaultValue = DefaultValue::with('foo');
+
+        $this->assertEquals(['value' => 'foo'], $defaultValue->jsonSerialize());
+    }
+}

--- a/tests/Unit/RemoteConfig/ParameterTest.php
+++ b/tests/Unit/RemoteConfig/ParameterTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
+
+use Kreait\Firebase\Exception\InvalidArgumentException;
+use Kreait\Firebase\RemoteConfig\DefaultValue;
+use Kreait\Firebase\RemoteConfig\Parameter;
+use Kreait\Firebase\Tests\UnitTestCase;
+
+class ParameterTest extends UnitTestCase
+{
+    public function testCreateWithImplicitDefaultValue()
+    {
+        $parameter = Parameter::named('empty');
+
+        $this->assertEquals(DefaultValue::none(), $parameter->defaultValue());
+    }
+
+    public function testCreateWithDefaultValue()
+    {
+        $parameter = Parameter::named('with_default_foo', 'foo');
+
+        $this->assertEquals(DefaultValue::with('foo'), $parameter->defaultValue());
+    }
+
+    public function testCreateWithInvalidDefaultValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Parameter::named('invalid', 1);
+    }
+}

--- a/tests/Unit/RemoteConfig/TagColorTest.php
+++ b/tests/Unit/RemoteConfig/TagColorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
+
+use Kreait\Firebase\Exception\InvalidArgumentException;
+use Kreait\Firebase\RemoteConfig\TagColor;
+use Kreait\Firebase\Tests\UnitTestCase;
+
+class TagColorTest extends UnitTestCase
+{
+    public function testCreateWithInvalidValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TagColor('foo');
+    }
+}

--- a/tests/Unit/RemoteConfig/TemplateTest.php
+++ b/tests/Unit/RemoteConfig/TemplateTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
+
+use Kreait\Firebase\Exception\InvalidArgumentException;
+use Kreait\Firebase\RemoteConfig\ConditionalValue;
+use Kreait\Firebase\RemoteConfig\Parameter;
+use Kreait\Firebase\RemoteConfig\TagColor;
+use Kreait\Firebase\RemoteConfig\Template;
+use Kreait\Firebase\Tests\UnitTestCase;
+
+class TemplateTest extends UnitTestCase
+{
+    public function testCreateWithInvalidConditionalValue()
+    {
+        $parameter = Parameter::named('foo')->withConditionalValue(new ConditionalValue('non_existing_condition', 'false'));
+
+        $this->expectException(InvalidArgumentException::class);
+        Template::new()->withParameter($parameter);
+    }
+}

--- a/tests/Unit/Util/JSONTest.php
+++ b/tests/Unit/Util/JSONTest.php
@@ -37,4 +37,11 @@ class JSONTest extends UnitTestCase
         $this->assertTrue(JSON::isValid(json_encode([])));
         $this->assertFalse(JSON::isValid('<html></html>'));
     }
+
+    public function testPrettyPrint()
+    {
+        $data = ['foo' => 'bar'];
+
+        $this->assertSame(json_encode($data, JSON_PRETTY_PRINT), JSON::prettyPrint($data));
+    }
 }


### PR DESCRIPTION
Today, Firebase announced a new REST API for accessing the Firebase Remote Config: https://firebase.googleblog.com/2018/03/announcing-remote-config-rest-api.html

~Please check the documentation at https://github.com/kreait/firebase-php/blob/feature/remote-config/docs/remote-config.rst for a quick start on how to use it with this library.~ (the docs are currently not up to date)

Here is my manual test script:

```php
<?php

declare(strict_types=1);

use Kreait\Firebase;
use Kreait\Firebase\RemoteConfig\Condition;
use Kreait\Firebase\RemoteConfig\ConditionalValue;
use Kreait\Firebase\RemoteConfig\Parameter;
use Kreait\Firebase\RemoteConfig\TagColor;
use Kreait\Firebase\RemoteConfig\Template;
use Kreait\Firebase\Util\JSON;

require_once __DIR__.'/vendor/autoload.php';

$firebase = (new Firebase\Factory())->create();

$remoteConfig = $firebase->getRemoteConfig();

// Get and print the existing remote config
echo JSON::prettyPrint($remoteConfig->get()).PHP_EOL;

// -----------------
// Define conditions
$germanLanguageCondition = Condition::named('lang_german')
    ->withExpression("device.language in ['de', 'de_AT', 'de_CH']")
    ->withTagColor(TagColor::ORANGE);

// Alternative notation
$frenchLanguageCondition = Condition::fromArray([
    'name' => 'lang_french',
    'expression' => "device.language in ['fr', 'fr_CA', 'fr_CH']",
    'tagColor' => TagColor::GREEN
]);

// -------------------------
// Define conditional values
$germanWelcomeMessage = ConditionalValue::basedOn($germanLanguageCondition)->withValue('Willkommen!');
// Alternative notation
$frenchWelcomeMessage = new ConditionalValue('lang_french', 'Bienvenu!');

// -----------------
// Define parameters
$welcomeMessageParameter = Parameter::named('welcome_message')
    ->defaultingTo('Welcome!')
    ->describedWith('This is a welcome message')
    ->withConditionalValue($germanWelcomeMessage)
    ->withConditionalValue($frenchWelcomeMessage)
;

// ---------------
// Create template with the given conditions and parameters
$template = Template::new()
    // When a parameter has a conditional value, the condition must be added before the parameter
    ->withCondition($germanLanguageCondition)
    ->withCondition($frenchLanguageCondition)
    ->withParameter($welcomeMessageParameter)
;

echo JSON::prettyPrint($template);

// ----------------
// Publish template
try {
    $etag = $remoteConfig->publish($template);
} catch (\Throwable $e) {
    echo 'ERROR: '.$e->getMessage();
    exit;
}

echo $etag.PHP_EOL;

```

Result:

<img width="611" src="https://user-images.githubusercontent.com/67554/38044822-282b18ee-32bb-11e8-8e99-e4f3a33c82e0.png">

<img width="665" src="https://user-images.githubusercontent.com/67554/38044879-4c52ef1c-32bb-11e8-8d0a-88b02d23a7a4.png">

## Todo

- [ ] Update documentation
- [x] Write unit and integration tests

:octocat: 