### PR TITLE
Fix setting email verification flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+### Bugfix
+
+- Fixed setting email verification flags ([#183](https://github.com/kreait/firebase-php/issues/183)) 
+
 ## 4.2.1 - 2018-03-14
 
 ### Bugfix

--- a/src/Firebase/Request/EditUserTrait.php
+++ b/src/Firebase/Request/EditUserTrait.php
@@ -86,7 +86,7 @@ trait EditUserTrait
                 case 'emailverified':
                     if ($value) {
                         $request = $request->markEmailAsVerified();
-                    } else {
+                    } elseif (false === $value) {
                         $request = $request->markEmailAsUnverified();
                     }
                     break;
@@ -253,10 +253,6 @@ trait EditUserTrait
         ], function ($value) {
             return null !== $value;
         });
-
-        if (array_key_exists('emailVerified', $data) && !array_key_exists('email', $data)) {
-            unset($data['emailVerified']);
-        }
 
         return $data;
     }

--- a/tests/Integration/Request/CreateUserTest.php
+++ b/tests/Integration/Request/CreateUserTest.php
@@ -43,4 +43,34 @@ class CreateUserTest extends IntegrationTestCase
 
         $this->auth->deleteUser($user->uid);
     }
+
+    public function testCreateUserWithoutEmailButMarkTheEmailAsVerified()
+    {
+        $request = CreateUser::new()
+            ->withUid($uid = bin2hex(random_bytes(5)))
+            ->markEmailAsVerified();
+
+        $user = $this->auth->createUser($request);
+
+        $this->assertSame($uid, $user->uid);
+        $this->assertNull($user->email);
+        $this->assertNull($user->emailVerified);
+
+        $this->auth->deleteUser($user->uid);
+    }
+
+    public function testCreateUserWithoutEmailButMarkTheEmailAsUnverified()
+    {
+        $request = CreateUser::new()
+            ->withUid($uid = bin2hex(random_bytes(5)))
+            ->markEmailAsUnverified();
+
+        $user = $this->auth->createUser($request);
+
+        $this->assertSame($uid, $user->uid);
+        $this->assertNull($user->email);
+        $this->assertNull($user->emailVerified);
+
+        $this->auth->deleteUser($user->uid);
+    }
 }

--- a/tests/Integration/Request/UpdateUserTest.php
+++ b/tests/Integration/Request/UpdateUserTest.php
@@ -48,4 +48,61 @@ class UpdateUserTest extends IntegrationTestCase
 
         $this->auth->deleteUser($user->uid);
     }
+
+    public function testMarkNonExistingEmailAsVerified()
+    {
+        $user = $this->auth->createUser(
+            CreateUser::new()
+                ->withUid($uid = bin2hex(random_bytes(5)))
+        );
+
+        $this->assertNotTrue($user->emailVerified);
+        $this->assertNull($user->email);
+
+        $updatedUser = $this->auth->updateUser($uid, UpdateUser::new()->markEmailAsVerified());
+
+        $this->assertSame($user->uid, $updatedUser->uid);
+        $this->assertNull($updatedUser->email);
+        $this->assertTrue($updatedUser->emailVerified);
+
+        $this->auth->deleteUser($updatedUser->uid);
+    }
+
+    public function testMarkExistingUnverifiedEmailAsVerified()
+    {
+        $user = $this->auth->createUser(
+            CreateUser::new()
+                ->withUid($uid = bin2hex(random_bytes(5)))
+                ->withUnverifiedEmail($email = $uid.'@example.org')
+        );
+
+        $this->assertFalse($user->emailVerified);
+
+        $updatedUser = $this->auth->updateUser($uid, UpdateUser::new()->markEmailAsVerified());
+
+        $this->assertSame($user->uid, $updatedUser->uid);
+        $this->assertSame($user->email, $updatedUser->email);
+        $this->assertTrue($updatedUser->emailVerified);
+
+        $this->auth->deleteUser($updatedUser->uid);
+    }
+
+    public function testMarkExistingVerifiedEmailAsUnverified()
+    {
+        $user = $this->auth->createUser(
+            CreateUser::new()
+                ->withUid($uid = bin2hex(random_bytes(5)))
+                ->withVerifiedEmail($email = $uid.'@example.org')
+        );
+
+        $this->assertTrue($user->emailVerified);
+
+        $updatedUser = $this->auth->updateUser($uid, UpdateUser::new()->markEmailAsUnverified());
+
+        $this->assertSame($user->uid, $updatedUser->uid);
+        $this->assertSame($user->email, $updatedUser->email);
+        $this->assertFalse($updatedUser->emailVerified);
+
+        $this->auth->deleteUser($updatedUser->uid);
+    }
 }

--- a/tests/Unit/Request/CreateUserTest.php
+++ b/tests/Unit/Request/CreateUserTest.php
@@ -56,7 +56,7 @@ class CreateUserTest extends TestCase
             ],
             'no_email_but_verification_flag' => [
                 $given + ['emailVerified' => true],
-                $expected,
+                $expected + ['emailVerified' => true],
             ],
             'disabled_1' => [
                 $given + ['disabled' => true],

--- a/tests/Unit/Request/UpdateUserTest.php
+++ b/tests/Unit/Request/UpdateUserTest.php
@@ -85,6 +85,18 @@ class UpdateUserTest extends TestCase
                 $given + ['deleteAttributes' => ['displayname']],
                 $expected + ['deleteAttribute' => [UpdateUser::DISPLAY_NAME]],
             ],
+            [
+                $given + ['emailVerified' => true],
+                $expected + ['emailVerified' => true],
+            ],
+            [
+                $given + ['emailVerified' => false],
+                $expected + ['emailVerified' => false],
+            ],
+            [
+                $given + ['emailVerified' => null],
+                $expected,
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes #183 

Includes unit and integration tests to ensure that the `emailVerified` flag is set as expected.

:octocat: 