### PR TITLE
Implement FCM topic management

### DIFF
--- a/docs/cloud-messaging.rst
+++ b/docs/cloud-messaging.rst
@@ -328,3 +328,49 @@ Sending a fully configured raw message
                 ],
             ],
         ])
+
+****************
+Topic management
+****************
+
+Subscribe to a topic
+--------------------
+
+You can subscribe one or multiple devices to a topic by passing registration tokens to the
+``subscribeToTopic()`` method.
+
+.. code-block:: php
+
+    $topic = 'my-topic';
+    $registrationTokens = [
+        // ...
+    };
+
+    $firebase
+        ->getMessaging()
+        ->subscribeToTopic($topic, $registrationTokens);
+
+.. note::
+    You can subscribe up to 1,000 devices in a single request. If you provide an array with over 1,000
+    registration tokens, the operation will fail with an error.
+
+Unsubscribe from a topic
+------------------------
+
+You can unsubscribe one or multiple devices from a topic by passing registration tokens to the
+``unsubscribeFromTopic()`` method.
+
+.. code-block:: php
+
+    $topic = 'my-topic';
+    $registrationTokens = [
+        // ...
+    };
+
+    $firebase
+        ->getMessaging()
+        ->unsubscribeFromTopic($topic, $registrationTokens);
+
+.. note::
+    You can unsubscribe up to 1,000 devices in a single request. If you provide an array with over 1,000
+    registration tokens, the operation will fail with an error.

--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -191,11 +191,22 @@ class Factory
         $serviceAccount = $this->getServiceAccount();
         $projectId = $serviceAccount->getProjectId();
 
-        $http = $this->createApiClient($this->getServiceAccount(), [
-            'base_uri' => 'https://fcm.googleapis.com/v1/projects/'.$projectId,
-        ]);
+        $messagingApiClient = new Messaging\ApiClient(
+            $this->createApiClient($this->getServiceAccount(), [
+                'base_uri' => 'https://fcm.googleapis.com/v1/projects/'.$projectId,
+            ])
+        );
 
-        return new Messaging(new Messaging\ApiClient($http), new MessageFactory());
+        $topicManagementApiClient = new Messaging\TopicManagementApiClient(
+            $this->createApiClient($this->getServiceAccount(), [
+                'base_uri' => 'https://iid.googleapis.com',
+                'headers' => [
+                    'access_token_auth' => 'true',
+                ],
+            ])
+        );
+
+        return new Messaging($messagingApiClient, new MessageFactory(), $topicManagementApiClient);
     }
 
     protected function createApiClient(ServiceAccount $serviceAccount, array $config = []): Client

--- a/src/Firebase/Messaging/ApiClient.php
+++ b/src/Firebase/Messaging/ApiClient.php
@@ -4,6 +4,7 @@ namespace Kreait\Firebase\Messaging;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
 use Kreait\Firebase\Exception\MessagingException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;

--- a/src/Firebase/Messaging/TopicManagementApiClient.php
+++ b/src/Firebase/Messaging/TopicManagementApiClient.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Kreait\Firebase\Messaging;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use Kreait\Firebase\Exception\MessagingException;
+use Psr\Http\Message\ResponseInterface;
+
+class TopicManagementApiClient
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    public function subscribeToTopic($topic, array $tokens): ResponseInterface
+    {
+        return $this->request('POST', '/iid/v1:batchAdd', [
+            'json' => [
+                'to' => '/topics/'.$topic,
+                'registration_tokens' => $tokens,
+            ],
+        ]);
+    }
+
+    public function unsubscribeFromTopic($topic, array $tokens): ResponseInterface
+    {
+        return $this->request('POST', '/iid/v1:batchRemove', [
+            'json' => [
+                'to' => '/topics/'.$topic,
+                'registration_tokens' => $tokens,
+            ],
+        ]);
+    }
+
+    private function request($method, $endpoint, array $options = []): ResponseInterface
+    {
+        try {
+            return $this->client->request($method, $endpoint, $options);
+        } catch (RequestException $e) {
+            throw MessagingException::fromRequestException($e);
+        } catch (\Throwable $e) {
+            throw new MessagingException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/tests/Integration/MessageTestCase.php
+++ b/tests/Integration/MessageTestCase.php
@@ -9,7 +9,7 @@ use Kreait\Firebase\Messaging\MessageFactory;
 use Kreait\Firebase\Messaging\Notification;
 use Kreait\Firebase\Tests\IntegrationTestCase;
 
-abstract class MessagingTestCase extends IntegrationTestCase
+abstract class MessageTestCase extends IntegrationTestCase
 {
     /**
      * @var Messaging
@@ -31,7 +31,29 @@ abstract class MessagingTestCase extends IntegrationTestCase
         $this->messaging = self::$firebase->getMessaging();
         $this->messageFactory = new MessageFactory();
 
-        $this->fullMessageData = [
+        $this->fullMessageData = self::createFullMessageData();
+    }
+
+    protected function assertSuccessfulMessage($message)
+    {
+        $result = $this->messaging->send($message);
+
+        $this->assertTrue($noExceptionHasBeenThrown = true);
+
+        return $result;
+    }
+
+    abstract public function testSendEmptyMessage();
+
+    public function testSendFullMessage()
+    {
+        $message = $this->messageFactory->fromArray($this->fullMessageData);
+        $this->assertSuccessfulMessage($message);
+    }
+
+    public static function createFullMessageData(): array
+    {
+        return [
             'notification' => [
                 'title' => 'Notification title',
                 'body' => 'Notification body',
@@ -75,21 +97,5 @@ abstract class MessagingTestCase extends IntegrationTestCase
                 ],
             ],
         ];
-    }
-
-    protected function assertSuccessfulMessage($message)
-    {
-        $result = $this->messaging->send($message);
-
-        $this->assertTrue($noExceptionHasBeenThrown = true);
-
-        return $result;
-    }
-
-    abstract public function testSendEmptyMessage();
-
-    public function testSendFullMessage()
-    {
-        $this->assertSuccessfulMessage($this->messageFactory->fromArray($this->fullMessageData));
     }
 }

--- a/tests/Integration/Messaging/ConditionalMessageTest.php
+++ b/tests/Integration/Messaging/ConditionalMessageTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Tests\Integration\Messaging;
 
 use Kreait\Firebase\Messaging\ConditionalMessage;
-use Kreait\Firebase\Tests\Integration\MessagingTestCase;
+use Kreait\Firebase\Tests\Integration\MessageTestCase;
 
-class ConditionalMessageTest extends MessagingTestCase
+class ConditionalMessageTest extends MessageTestCase
 {
     private $condition;
 

--- a/tests/Integration/Messaging/MessageToRegistrationTokenTest.php
+++ b/tests/Integration/Messaging/MessageToRegistrationTokenTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Tests\Integration\Messaging;
 
 use Kreait\Firebase\Messaging\MessageToRegistrationToken;
-use Kreait\Firebase\Tests\Integration\MessagingTestCase;
+use Kreait\Firebase\Tests\Integration\MessageTestCase;
 
-class MessageToRegistrationTokenTest extends MessagingTestCase
+class MessageToRegistrationTokenTest extends MessageTestCase
 {
     /**
      * @var string

--- a/tests/Integration/Messaging/MessageToTopicTest.php
+++ b/tests/Integration/Messaging/MessageToTopicTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Tests\Integration\Messaging;
 
 use Kreait\Firebase\Messaging\MessageToTopic;
-use Kreait\Firebase\Tests\Integration\MessagingTestCase;
+use Kreait\Firebase\Tests\Integration\MessageTestCase;
 
-class MessageToTopicTest extends MessagingTestCase
+class MessageToTopicTest extends MessageTestCase
 {
     private $topic;
 

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Integration;
+
+use Kreait\Firebase\Messaging;
+use Kreait\Firebase\Tests\IntegrationTestCase;
+
+class MessagingTest extends IntegrationTestCase
+{
+    /**
+     * @var Messaging
+     */
+    public $messaging;
+
+    protected function setUp()
+    {
+        $this->messaging = self::$firebase->getMessaging();
+    }
+
+    public function testSendMessage()
+    {
+        $message = MessageTestCase::createFullMessageData();
+        $message['condition'] = "'dogs' in topics || 'cats' in topics";
+
+        $this->messaging->send($message);
+        $this->assertTrue($noExceptionHasBeenThrown = true);
+    }
+
+    public function testSubscribeToTopic()
+    {
+        $this->messaging->subscribeToTopic('foo', self::$registrationTokens);
+        $this->assertTrue($noExceptionHasBeenThrown = true);
+    }
+
+    public function testUnsubscribeFromTopic()
+    {
+        $this->messaging->unsubscribeFromTopic('foo', self::$registrationTokens);
+        $this->assertTrue($noExceptionHasBeenThrown = true);
+    }
+}

--- a/tests/Unit/MessagingTest.php
+++ b/tests/Unit/MessagingTest.php
@@ -2,10 +2,13 @@
 
 namespace Kreait\Firebase\Tests\Unit;
 
+use GuzzleHttp\Psr7\Response;
 use Kreait\Firebase\Exception\InvalidArgumentException;
+use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 use Kreait\Firebase\Messaging;
 use Kreait\Firebase\Messaging\ApiClient;
 use Kreait\Firebase\Messaging\MessageFactory;
+use Kreait\Firebase\Messaging\TopicManagementApiClient;
 use Kreait\Firebase\Tests\UnitTestCase;
 
 class MessagingTest extends UnitTestCase
@@ -18,7 +21,12 @@ class MessagingTest extends UnitTestCase
     /**
      * @var ApiClient
      */
-    private $apiClient;
+    private $messagingApi;
+
+    /**
+     * @var TopicManagementApiClient
+     */
+    private $topicManagementApi;
 
     /**
      * @var MessageFactory
@@ -28,9 +36,10 @@ class MessagingTest extends UnitTestCase
     protected function setUp()
     {
         $this->messageFactory = new MessageFactory();
-        $this->apiClient = $this->createMock(ApiClient::class);
+        $this->messagingApi = $this->createMock(ApiClient::class);
+        $this->topicManagementApi = $this->createMock(TopicManagementApiClient::class);
 
-        $this->messaging = new Messaging($this->apiClient, $this->messageFactory);
+        $this->messaging = new Messaging($this->messagingApi, $this->messageFactory, $this->topicManagementApi);
     }
 
     public function testSendInvalidObject()
@@ -43,5 +52,68 @@ class MessagingTest extends UnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->messaging->send([]);
+    }
+
+    /**
+     * @dataProvider validTokenProvider
+     */
+    public function testSubscribeToTopicWithValidTokens($tokens)
+    {
+        $this->topicManagementApi->expects($this->once())
+            ->method($this->anything())
+            ->willReturn(new Response(200, [], '[]'));
+
+        $this->messaging->subscribeToTopic('topic', $tokens);
+        $this->assertTrue($noExceptionHasBeenThrown = true);
+    }
+
+    /**
+     * @dataProvider invalidTokenProvider
+     */
+    public function testSubscribeToTopicWithInvalidTokens($tokens)
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->messaging->subscribeToTopic('topic', $tokens);
+    }
+
+    /**
+     * @dataProvider validTokenProvider
+     */
+    public function testUnsubscribeFromTopicWithValidTokens($tokens)
+    {
+        $this->topicManagementApi->expects($this->once())
+            ->method($this->anything())
+            ->willReturn(new Response(200, [], '[]'));
+
+        $this->messaging->unsubscribeFromTopic('topic', $tokens);
+        $this->assertTrue($noExceptionHasBeenThrown = true);
+    }
+
+    /**
+     * @dataProvider invalidTokenProvider
+     */
+    public function testUnsubscribeFromTopicWithInvalidTokens($tokens)
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->messaging->unsubscribeFromTopic('topic', $tokens);
+    }
+
+    public function validTokenProvider()
+    {
+        return [
+            ['foo'],
+            [['foo']],
+            [Messaging\RegistrationToken::fromValue('foo')],
+            [[Messaging\RegistrationToken::fromValue('foo')]],
+        ];
+    }
+
+    public function invalidTokenProvider()
+    {
+        return [
+            [null],
+            [[]],
+            [1],
+        ];
     }
 }

--- a/tests/Unit/Request/CreateUserTest.php
+++ b/tests/Unit/Request/CreateUserTest.php
@@ -86,6 +86,10 @@ class CreateUserTest extends TestCase
                 $given + ['isEnabled' => true],
                 $expected + ['disableUser' => false],
             ],
+            'explicitely_disabled_user_1' => [
+                $given + ['enabled' => false],
+                $expected + ['disableUser' => true],
+            ],
             'enableUser' => [
                 $given + ['enableUser' => true],
                 $expected + ['disableUser' => false],


### PR DESCRIPTION
Adds methods to subscribe and unsubscribe devices to and from topics.

### How to test

```php
<?php

declare(strict_types=1);

use Kreait\Firebase;
use Kreait\Firebase\Util\JSON;

require_once __DIR__.'/vendor/autoload.php';

$serviceAccount = Firebase\ServiceAccount::fromJsonFile('/path/to/credentials.json');

$firebase = (new Firebase\Factory())
    ->withServiceAccount($serviceAccount)
    ->create();

$messaging = $firebase->getMessaging();
$tokens = [
    // ...
];

echo JSON::prettyPrint($messaging->subscribeToTopic('foo', $tokens));
echo JSON::prettyPrint($messaging->unsubscribeFromTopic('foo', $tokens));
```

### Todo

- [x] Add tests
- [x] Add documentation