### PR TITLE
Improve inheritance for type-hinting messages

### DIFF
--- a/src/Firebase/Messaging/ConditionalMessage.php
+++ b/src/Firebase/Messaging/ConditionalMessage.php
@@ -6,10 +6,8 @@ namespace Kreait\Firebase\Messaging;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
 
-class ConditionalMessage implements Message
+class ConditionalMessage extends Message
 {
-    use MessageTrait;
-
     /**
      * @var Condition
      */

--- a/src/Firebase/Messaging/Message.php
+++ b/src/Firebase/Messaging/Message.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\Messaging;
 
-interface Message extends \JsonSerializable
+abstract class Message implements \JsonSerializable
 {
+    use MessageTrait;
 }

--- a/src/Firebase/Messaging/MessageToRegistrationToken.php
+++ b/src/Firebase/Messaging/MessageToRegistrationToken.php
@@ -6,10 +6,8 @@ namespace Kreait\Firebase\Messaging;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
 
-class MessageToRegistrationToken implements Message
+class MessageToRegistrationToken extends Message
 {
-    use MessageTrait;
-
     /**
      * @var RegistrationToken
      */

--- a/src/Firebase/Messaging/MessageToTopic.php
+++ b/src/Firebase/Messaging/MessageToTopic.php
@@ -6,10 +6,8 @@ namespace Kreait\Firebase\Messaging;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
 
-class MessageToTopic implements Message
+class MessageToTopic extends Message
 {
-    use MessageTrait;
-
     /**
      * @var Topic
      */


### PR DESCRIPTION
I ran into a problem passing around `Message` instances in my code. All three message types (`MessageToTopic`, `MessageToRegistrationToken`, and `ConditionalMessage`) implement the `Message` interface, but that interface does not guarantee access to properties like the notification. Therefore I suggest replacing the interface by an abstract class that implements the `MessageTrait`.