### PR TITLE
Email Verification and Password Reset support continueUrl

### DIFF
--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -214,6 +214,7 @@ class Auth
 
     /**
      * @param string $uid
+     * @param string $continueUrl
      */
     public function sendEmailVerification(string $uid, string $continueUrl = null)
     {

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -215,7 +215,7 @@ class Auth
     /**
      * @param string $uid
      */
-    public function sendEmailVerification(string $uid)
+    public function sendEmailVerification(string $uid, string $continueUrl = null)
     {
         $response = $this->client->exchangeCustomTokenForIdAndRefreshToken(
             $this->createCustomToken($uid)
@@ -223,12 +223,12 @@ class Auth
 
         $idToken = JSON::decode((string) $response->getBody(), true)['idToken'];
 
-        $this->client->sendEmailVerification($idToken);
+        $this->client->sendEmailVerification($idToken, $continueUrl);
     }
 
-    public function sendPasswordResetEmail(string $email)
+    public function sendPasswordResetEmail(string $email, string $continueUrl = null)
     {
-        $this->client->sendPasswordResetEmail($email);
+        $this->client->sendPasswordResetEmail($email, $continueUrl);
     }
 
     public function setCustomUserAttributes(string $uid, array $attributes): UserRecord

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -194,19 +194,21 @@ class ApiClient
      *
      * @return ResponseInterface
      */
-    public function sendEmailVerification(string $idToken): ResponseInterface
+    public function sendEmailVerification(string $idToken, string $continueUrl = null): ResponseInterface
     {
         return $this->request('getOobConfirmationCode', [
             'requestType' => 'VERIFY_EMAIL',
             'idToken' => $idToken,
+            'continueUrl' => $continueUrl,
         ]);
     }
 
-    public function sendPasswordResetEmail(string $email): ResponseInterface
+    public function sendPasswordResetEmail(string $email, string $continueUrl = null): ResponseInterface
     {
         return $this->request('getOobConfirmationCode', [
             'email' => $email,
             'requestType' => 'PASSWORD_RESET',
+            'continueUrl' => $continueUrl,
         ]);
     }
 

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -191,6 +191,7 @@ class ApiClient
 
     /**
      * @param string $idToken
+     * @param string $continueUrl
      *
      * @return ResponseInterface
      */

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -197,20 +197,20 @@ class ApiClient
      */
     public function sendEmailVerification(string $idToken, string $continueUrl = null): ResponseInterface
     {
-        return $this->request('getOobConfirmationCode', [
+        return $this->request('getOobConfirmationCode', array_filter([
             'requestType' => 'VERIFY_EMAIL',
             'idToken' => $idToken,
             'continueUrl' => $continueUrl,
-        ]);
+        ]));
     }
 
     public function sendPasswordResetEmail(string $email, string $continueUrl = null): ResponseInterface
     {
-        return $this->request('getOobConfirmationCode', [
+        return $this->request('getOobConfirmationCode', array_filter([
             'email' => $email,
             'requestType' => 'PASSWORD_RESET',
             'continueUrl' => $continueUrl,
-        ]);
+        ]));
     }
 
     public function revokeRefreshTokens(string $uid): ResponseInterface


### PR DESCRIPTION
Adds support for continueUrl to reset password and verify email emails that go out as per https://firebase.google.com/docs/auth/custom-email-handler