### PR TITLE
Changed CloudMessage properties privacy level from private to protected

### DIFF
--- a/src/Firebase/Messaging/CloudMessage.php
+++ b/src/Firebase/Messaging/CloudMessage.php
@@ -11,32 +11,32 @@ class CloudMessage implements Message
     /**
      * @var MessageTarget
      */
-    private $target;
+    protected $target;
 
     /**
      * @var MessageData|null
      */
-    private $data;
+    protected $data;
 
     /**
      * @var Notification|null
      */
-    private $notification;
+    protected $notification;
 
     /**
      * @var AndroidConfig|null
      */
-    private $androidConfig;
+    protected $androidConfig;
 
     /**
      * @var ApnsConfig|null
      */
-    private $apnsConfig;
+    protected $apnsConfig;
 
     /**
      * @var WebPushConfig|null
      */
-    private $webPushConfig;
+    protected $webPushConfig;
 
     private function __construct()
     {


### PR DESCRIPTION
Making all properties private prevents from extending and simple child object initialization in __construct.
It would be nice not to use "private" everywhere and give more flexibility here.
For example would be possible to define classes like:  FriendIsOnlineNotification, NewMessageNotification and etc which would extend from CloudMessage class.