### PR TITLE
Implementing FCM sendAll and sendMulticast APIs.

### DIFF
--- a/src/Firebase/Exception/MessagingException.php
+++ b/src/Firebase/Exception/MessagingException.php
@@ -38,32 +38,45 @@ class MessagingException extends \RuntimeException implements FirebaseException
 
         $code = (int) ($errors['error']['code'] ?? $e->getCode());
         $message = $errors['error']['message'] ?? $reasonPhrase;
-
-        switch ($code) {
-            case 400:
-                $error = new InvalidMessage($message ?: 'Invalid message', $code, $e);
-                break;
-            case 401:
-            case 403:
-                $error = new AuthenticationError($message ?: 'Authentication error', $code, $e);
-                break;
-            case 404:
-                $error = new NotFound($message ?: 'Not found', $code, $e);
-                break;
-            case 500:
-                $error = new ServerError($message ?: 'Server error', $code, $e);
-                break;
-            case 503:
-                $error = new ServerUnavailable($message ?: 'Server unavailable', $code, $e);
-                break;
-            default:
-                $error = new UnknownError($message ?: 'Unknown error', $code, $e);
-                break;
-        }
+        $error = self::createExceptionMessage($code, $message, $e);
 
         return $error
             ->withResponse($response)
             ->withErrors($errors);
+    }
+
+    public static function fromResponse(ResponseInterface $response): self
+    {
+        $reasonPhrase = null;
+        $errors = self::getErrorsFromResponse($response);
+        $reasonPhrase = $response->getReasonPhrase();
+
+        $code = (int) ($errors['error']['code'] ?? $response->getStatusCode());
+        $message = $errors['error']['message'] ?? $reasonPhrase;
+        $error = self::createExceptionMessage($code, $message);
+
+        return $error
+            ->withResponse($response)
+            ->withErrors($errors);
+    }
+
+    private static function createExceptionMessage($code, $message, $e = null)
+    {
+        switch ($code) {
+            case 400:
+                return new InvalidMessage($message ?: 'Invalid message', $code, $e);
+            case 401:
+            case 403:
+                return new AuthenticationError($message ?: 'Authentication error', $code, $e);
+            case 404:
+                return new NotFound($message ?: 'Not found', $code, $e);
+            case 500:
+                return new ServerError($message ?: 'Server error', $code, $e);
+            case 503:
+                return new ServerUnavailable($message ?: 'Server unavailable', $code, $e);
+            default:
+                return new UnknownError($message ?: 'Unknown error', $code, $e);
+        }
     }
 
     public function errors(): array

--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -266,11 +266,14 @@ class Factory
     {
         $projectId = $this->getServiceAccount()->getSanitizedProjectId();
 
-        $messagingApiClient = new Messaging\ApiClient(
-            $this->createApiClient([
-                'base_uri' => 'https://fcm.googleapis.com/v1/projects/'.$projectId,
-            ])
-        );
+        $http = $this->createApiClient([
+            'base_uri' => 'https://fcm.googleapis.com/v1/projects/'.$projectId,
+        ]);
+
+        /** @var HandlerStack $handler */
+        $handler = $http->getConfig('handler');
+        $handler->push(Middleware::parseMultipartResponse(), 'multipart_parser');
+        $messagingApiClient = new Messaging\ApiClient($http);
 
         $topicManagementApiClient = new Messaging\TopicManagementApiClient(
             $this->createApiClient([

--- a/src/Firebase/Http/MultipartResponse.php
+++ b/src/Firebase/Http/MultipartResponse.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Http;
+
+use GuzzleHttp\Psr7\Response;
+use function GuzzleHttp\Psr7\stream_for;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class MultipartResponse extends Response
+{
+    /** @var StreamInterface[] */
+    private $bodies = [];
+
+    /** @var string[] */
+    private $headers = [];
+
+    /**
+     * @param ResponseInterface $response
+     */
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response->getStatusCode(), $response->getHeaders(), null, $response->getProtocolVersion(), $response->getReasonPhrase());
+        $body = $response->getBody();
+        if (null === $body) {
+            $this->withoutHeader('Content-Length');
+            $this->withoutHeader('Transfer-Encoding');
+        } else {
+            foreach (self::parseMultipartBody($body) as $parts) {
+                $this->bodies[] = stream_for($parts['body']);
+                $this->headers[] = $parts['headers'];
+            }
+        }
+    }
+
+    public function getBody()
+    {
+        return array_shift($this->bodies);
+    }
+
+    public function getHeaders()
+    {
+        return array_shift($this->headers);
+    }
+
+    /**
+     * Parses a multipart body into multiple parts.
+     *
+     * @param StreamInterface $stream
+     *
+     * @return array
+     */
+    public static function parseMultipartBody(StreamInterface $stream)
+    {
+        $parts = [];
+        $payload = (string) $stream;
+        preg_match('/--(.*)\b/', $payload, $boundary);
+        if (!empty($boundary)) {
+            $messages = array_filter(array_map('trim', explode($boundary[0], $payload)));
+            foreach ($messages as $message) {
+                if ($message == '--') {
+                    break;
+                }
+                $headers = [];
+                list($header_lines, $body) = explode("\r\n\r\n", $message, 2);
+                foreach (explode("\r\n", $header_lines) as $header_line) {
+                    list($key, $value) = preg_split('/:\s+/', $header_line, 2);
+                    $headers[strtolower($key)] = explode(', ', $value);
+                }
+                $parts[] = [
+                    'headers' => $headers,
+                    'body' => $body,
+                ];
+            }
+        }
+        return $parts;
+    }
+}

--- a/src/Firebase/Messaging/BaseClient.php
+++ b/src/Firebase/Messaging/BaseClient.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Messaging;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
+use Kreait\Firebase\Exception\MessagingException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use Throwable;
+
+abstract class BaseClient
+{
+    /**
+     * @var ClientInterface
+     */
+    protected $client;
+
+    /**
+     * @internal
+     */
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    protected function sendAsync(RequestInterface $request, array $options = null): PromiseInterface
+    {
+        $options = $options ?? [];
+
+        return $this->client->sendAsync($request, $options)
+            ->then(null, function (Throwable $e) {
+                throw $this->convertError($e);
+            });
+    }
+
+    protected function createRequest(string $method, string $endpoint): Request
+    {
+        /** @var UriInterface $uri */
+        $uri = $this->client->getConfig('base_uri');
+        $path = \rtrim($uri->getPath(), '/').'/'.\ltrim($endpoint, '/');
+        $uri = $uri->withPath($path);
+
+        return new Request($method, $uri);
+    }
+
+    protected function convertError(Throwable $error): MessagingException
+    {
+        if ($error instanceof RequestException) {
+            return MessagingException::fromRequestException($error);
+        }
+
+        return new MessagingException($error->getMessage(), $error->getCode(), $error);
+    }
+}

--- a/src/Firebase/Messaging/BatchRequestClient.php
+++ b/src/Firebase/Messaging/BatchRequestClient.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Messaging;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class BatchRequestClient extends BaseClient
+{
+    const PART_BOUNDARY = '__END_OF_PART__';
+
+    /**
+     * @var string
+     */
+    protected $batchUri;
+
+    /**
+     * @var array
+     */
+    protected $headers;
+
+    public function __construct(ClientInterface $client, string $batchUri, array $headers = [])
+    {
+        parent::__construct($client);
+        $this->batchUri = $batchUri;
+        $this->headers = $headers;
+    }
+
+    public function sendBatchRequest(SubRequestCollection $requests): ResponseInterface
+    {
+        return $this->sendBatchRequestAsync($requests)->wait();
+    }
+
+    public function sendBatchRequestAsync(SubRequestCollection $requests): PromiseInterface
+    {
+        $boundary = self::PART_BOUNDARY;
+        return $this->sendAsync(new Request('POST', $this->batchUri), [
+            'headers' => [
+                'Content-Type' => "multipart/mixed; boundary={$boundary}",
+            ],
+            'body' => $this->getMultipartPayload($requests, $boundary),
+        ]);
+    }
+
+    protected function getMultipartPayload(SubRequestCollection $requests, $boundary): string
+    {
+        $buffer = '';
+        foreach ($requests as $idx => $request) {
+            $buffer .= $this->createPart($request, $boundary , $idx);
+        }
+        $buffer .= "--{$boundary}--\r\n";
+
+        return $buffer;
+    }
+
+    protected function createPart($request, string $boundary, int $idx): string
+    {
+        $serializedRequest = $this->serializeSubRequest($request);
+        $headers = $this->getHeaders(strlen($serializedRequest), $idx);
+        $part = "--{$boundary}\r\n";
+        foreach ($headers as $key => $value) {
+            $part .= "{$key}: {$value}\r\n";
+        }
+        $part .= "\r\n";
+        $part .= "{$serializedRequest}\r\n";
+
+        return $part;
+    }
+
+    protected function serializeSubRequest(RequestInterface $request): string
+    {
+        $request->withHeader('Content-Length', $request->getBody()->getSize());
+        $request->withHeader('Content-Type', 'application/json; charset=UTF-8');
+
+        return \GuzzleHttp\Psr7\str($request);
+    }
+
+    protected function getHeaders(int $length, int $idx): array
+    {
+        return [
+            'Content-Length' => $length,
+            'Content-Type' => 'application/http',
+            'content-id' => $idx + 1,
+            'content-transfer-encoding' => 'binary',
+        ];
+    }
+}

--- a/src/Firebase/Messaging/CloudMessage.php
+++ b/src/Firebase/Messaging/CloudMessage.php
@@ -199,6 +199,11 @@ class CloudMessage implements Message
         return $this->target ? true : false;
     }
 
+    public function getTarget(): MessageTarget
+    {
+        return $this->target;
+    }
+
     public function jsonSerialize()
     {
         $data = [

--- a/src/Firebase/Messaging/CloudMessageCollection.php
+++ b/src/Firebase/Messaging/CloudMessageCollection.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Messaging;
+
+use Traversable;
+
+/**
+ * Class CloudMessageCollection
+ * @package Kreait\Firebase\Messaging
+ */
+class CloudMessageCollection implements \IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    private $messages;
+
+    /**
+     * CloudMessageCollection constructor.
+     */
+    public function __construct()
+    {
+        $this->messages = [];
+    }
+
+    /**
+     * Retrieve an external iterator
+     * @link https://php.net/manual/en/iteratoraggregate.getiterator.php
+     * @return Traversable An instance of an object implementing <b>Iterator</b> or
+     * <b>Traversable</b>
+     * @since 5.0.0
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->messages);
+    }
+
+    /**
+     * Append message.
+     * @param CloudMessage $message
+     */
+    public function addMessage(CloudMessage $message)
+    {
+        $this->messages[] = $message;
+    }
+}

--- a/src/Firebase/Messaging/MulticastSendReport.php
+++ b/src/Firebase/Messaging/MulticastSendReport.php
@@ -11,6 +11,10 @@ final class MulticastSendReport implements Countable
     /** @var SendReport[] */
     private $items = [];
 
+
+    /** @var int */
+    private $successCount = 0;
+
     private function __construct()
     {
     }
@@ -33,6 +37,9 @@ final class MulticastSendReport implements Countable
     {
         $new = clone $this;
         $new->items[] = $report;
+        if ($report->isSuccess()) {
+            $this->successCount++;
+        }
 
         return $new;
     }
@@ -67,5 +74,20 @@ final class MulticastSendReport implements Countable
     public function count(): int
     {
         return \count($this->items);
+    }
+
+    public function getSuccessCount()
+    {
+        return $this->successCount;
+    }
+
+    public function toArray(): array
+    {
+        $count = $this->count();
+        return [
+            'responses' => $this->getItems(),
+            'successCount' => $this->getSuccessCount(),
+            'failureCount' => $count - $this->getSuccessCount(),
+        ];
     }
 }

--- a/src/Firebase/Messaging/SubRequestCollection.php
+++ b/src/Firebase/Messaging/SubRequestCollection.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Messaging;
+
+use Psr\Http\Message\RequestInterface;
+use Traversable;
+
+/**
+ * Class SubRequestCollection
+ * @package Kreait\Firebase\Messaging
+ */
+class SubRequestCollection implements \IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    private $requests;
+
+    /**
+     * SubRequestCollection constructor.
+     */
+    public function __construct()
+    {
+        $this->requests = [];
+    }
+
+    /**
+     * Retrieve an external iterator
+     * @link https://php.net/manual/en/iteratoraggregate.getiterator.php
+     * @return Traversable An instance of an object implementing <b>Iterator</b> or
+     * <b>Traversable</b>
+     * @since 5.0.0
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->requests);
+    }
+
+    /**
+     * Append request.
+     * @param RequestInterface $request
+     */
+    public function addRequest(RequestInterface $request)
+    {
+        $this->requests[] = $request;
+    }
+}

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -36,6 +36,23 @@ class MessagingTest extends IntegrationTestCase
         $this->assertArrayHasKey('name', $result);
     }
 
+    public function testSendAllMessages()
+    {
+        $messages = [];
+        for ($i = 0; $i < 10; $i++) {
+            $message = MessageTestCase::createFullMessageData();
+            $message['condition'] = "'dogs' in topics || 'cats' in topics";
+            $messages[] = $message;
+        }
+
+        $reports = $this->messaging->sendAll($messages);
+        $result = $reports->toArray();
+
+        $this->assertArrayHasKey('responses', $result);
+        $this->assertArrayHasKey('successCount', $result);
+        $this->assertArrayHasKey('failureCount', $result);
+    }
+
     public function testSendRawMessage()
     {
         $data = MessageTestCase::createFullMessageData();

--- a/tests/Unit/Messaging/BatchRequestClientTest.php
+++ b/tests/Unit/Messaging/BatchRequestClientTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\Messaging;
+
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Kreait\Firebase\Exception\Messaging\AuthenticationError;
+use Kreait\Firebase\Exception\Messaging\InvalidArgument;
+use Kreait\Firebase\Exception\Messaging\ServerError;
+use Kreait\Firebase\Exception\Messaging\ServerUnavailable;
+use Kreait\Firebase\Exception\Messaging\UnknownError;
+use Kreait\Firebase\Exception\MessagingException;
+use PHPUnit\Framework\TestCase;
+use Kreait\Firebase\Messaging\BatchRequestClient;
+use Kreait\Firebase\Messaging\SubRequestCollection;
+
+/**
+ * @internal
+ */
+class BatchRequestClientTest extends TestCase
+{
+    /** @var MockHandler */
+    private $mock;
+
+    /** @var BatchRequestClient */
+    private $client;
+
+    protected function setUp()
+    {
+        $this->mock = new MockHandler();
+        $handler = HandlerStack::create($this->mock);
+        $client = new Client(['handler' => $handler]);
+
+        $this->client = new BatchRequestClient($client, 'http://example.com');
+    }
+
+    /**
+     * @dataProvider requestExceptions
+     */
+    public function testCatchRequestException($requestException, $expectedClass)
+    {
+        $this->mock->append($requestException);
+
+        $this->expectException($expectedClass);
+        $this->client->sendBatchRequest(new SubRequestCollection);
+    }
+
+    public function testCatchAnyException()
+    {
+        $this->mock->append(new Exception());
+
+        $this->expectException(MessagingException::class);
+
+        $this->client->sendBatchRequest(new SubRequestCollection);
+    }
+
+    public function requestExceptions(): array
+    {
+        $request = new Request('GET', 'http://example.com');
+        $responseBody = '{}';
+
+        return [
+            [
+                new RequestException('Bad Request', $request, new Response(400, [], $responseBody)),
+                InvalidArgument::class,
+            ],
+            [
+                new RequestException('Unauthorized', $request, new Response(401, [], $responseBody)),
+                AuthenticationError::class,
+            ],
+            [
+                new RequestException('Forbidden', $request, new Response(403, [], $responseBody)),
+                AuthenticationError::class,
+            ],
+            [
+                new RequestException('Internal Server Error', $request, new Response(500, [], $responseBody)),
+                ServerError::class,
+            ],
+            [
+                new RequestException('Service Unavailable', $request, new Response(503, [], $responseBody)),
+                ServerUnavailable::class,
+            ],
+            [
+                new RequestException('I\'m a teapot', $request, new Response(418, [], $responseBody)),
+                UnknownError::class,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
The sendMulticast() API uses the sendAll() method to send a single message to a batch of 100 tokens.