### PR TITLE
Implement link with oauth functionality

### DIFF
--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -11,6 +11,7 @@ use Firebase\Auth\Token\Exception\UnknownKey;
 use Generator;
 use Kreait\Firebase\Auth\ApiClient;
 use Kreait\Firebase\Auth\IdTokenVerifier;
+use Kreait\Firebase\Auth\LinkedProviderData;
 use Kreait\Firebase\Auth\UserRecord;
 use Kreait\Firebase\Exception\Auth\InvalidPassword;
 use Kreait\Firebase\Exception\Auth\RevokedIdToken;
@@ -471,6 +472,50 @@ class Auth
         $response = $this->client->unlinkProvider((string) $uid, $provider);
 
         return $this->getUserRecordFromResponse($response);
+    }
+
+    /**
+     * Logs in the user to Firebase by a provider's access token (like Google, Facebook, Twitter, etc),
+     * if the authentication provider is enabled for the project.
+     *
+     * First, you have to get a valid access token for your provider manually.
+     *
+     * @param Provider|string $provider
+     *
+     * @throws Exception\AuthException
+     * @throws Exception\FirebaseException
+     */
+    public function linkProviderThroughAccessToken($provider, string $accessToken): LinkedProviderData
+    {
+        $provider = $provider instanceof Provider ? $provider : new Provider($provider);
+        $response = $this->client->linkProviderThroughAccessToken($provider, $accessToken);
+
+        return LinkedProviderData::fromResponseData(
+            $this->getUserRecordFromResponse($response),
+            JSON::decode((string) $response->getBody(), true)
+        );
+    }
+
+    /**
+     * Logs in the user to Firebase by a provider's ID token (like Google, Facebook, Twitter, etc),
+     * if the authentication provider is enabled for the project.
+     *
+     * First, you have to get a valid ID token for your provider manually.
+     *
+     * @param Provider|string $provider
+     *
+     * @throws Exception\AuthException
+     * @throws Exception\FirebaseException
+     */
+    public function linkProviderThroughIdToken($provider, string $idToken): LinkedProviderData
+    {
+        $provider = $provider instanceof Provider ? $provider : new Provider($provider);
+        $response = $this->client->linkProviderThroughIdToken($provider, $idToken);
+
+        return LinkedProviderData::fromResponseData(
+            $this->getUserRecordFromResponse($response),
+            JSON::decode((string) $response->getBody(), true)
+        );
     }
 
     /**

--- a/src/Firebase/Auth/LinkedProviderData.php
+++ b/src/Firebase/Auth/LinkedProviderData.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Auth;
+
+use Kreait\Firebase\Value\Provider;
+
+class LinkedProviderData implements \JsonSerializable
+{
+    /**
+     * @var UserRecord
+     */
+    public $userRecord;
+
+    /**
+     * @var string
+     */
+    public $federatedId;
+
+    /**
+     * @var Provider
+     */
+    public $provider;
+
+    /**
+     * The Firebase ID token.
+     *
+     * @var string
+     */
+    public $idToken;
+
+    /**
+     * @var string|null
+     */
+    public $refreshToken;
+
+    /**
+     * The provider's ID token (e.g. Google ID token).
+     *
+     * @var string|null
+     */
+    public $oauthIdToken;
+
+    /**
+     * The provider's Access token (e.g. Facebook Access token).
+     *
+     * @var string|null
+     */
+    public $oauthAccessToken;
+
+    /**
+     * @var array
+     */
+    public $rawUserInfo;
+
+    public function __construct(UserRecord $userRecord)
+    {
+        $this->userRecord = $userRecord;
+    }
+
+    public static function fromResponseData(UserRecord $userRecord, array $data): self
+    {
+        $providerData = new self($userRecord);
+
+        $providerData->federatedId = $data['federatedId'];
+        $providerData->provider = new Provider($data['providerId']);
+        $providerData->idToken = $data['idToken'];
+        $providerData->refreshToken = $data['refreshToken'];
+        $providerData->oauthIdToken = $data['oauthIdToken'] ?? null;
+        $providerData->oauthAccessToken = $data['oauthAccessToken'] ?? null;
+        $providerData->rawUserInfo = \json_decode($data['rawUserInfo'], true);
+
+        return $providerData;
+    }
+
+    public function toArray(): array
+    {
+        return \get_object_vars($this);
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Firebase/Exception/Auth/ProviderLinkFailed.php
+++ b/src/Firebase/Exception/Auth/ProviderLinkFailed.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Exception\Auth;
+
+use Kreait\Firebase\Exception\AuthException;
+use Kreait\Firebase\Exception\HasRequestAndResponse;
+use RuntimeException;
+
+final class ProviderLinkFailed extends RuntimeException implements AuthException
+{
+    use HasRequestAndResponse;
+}

--- a/src/Firebase/Exception/AuthApiExceptionConverter.php
+++ b/src/Firebase/Exception/AuthApiExceptionConverter.php
@@ -16,6 +16,7 @@ use Kreait\Firebase\Exception\Auth\InvalidPassword;
 use Kreait\Firebase\Exception\Auth\MissingPassword;
 use Kreait\Firebase\Exception\Auth\OperationNotAllowed;
 use Kreait\Firebase\Exception\Auth\PhoneNumberExists;
+use Kreait\Firebase\Exception\Auth\ProviderLinkFailed;
 use Kreait\Firebase\Exception\Auth\UserDisabled;
 use Kreait\Firebase\Exception\Auth\UserNotFound;
 use Kreait\Firebase\Exception\Auth\WeakPassword;
@@ -106,6 +107,18 @@ class AuthApiExceptionConverter
 
         if (\mb_stripos($message, 'phone_number_exists') !== false) {
             return new PhoneNumberExists('The phone number is already in use by another account.', $code, $e);
+        }
+
+        if (\mb_stripos($message, 'invalid_idp_response') !== false) {
+            return new ProviderLinkFailed('The supplied auth credential is malformed or has expired.', $code, $e);
+        }
+
+        if (\mb_stripos($message, 'invalid_id_token') !== false) {
+            return new ProviderLinkFailed('The user\'s credential is no longer valid. The user must sign in again.', $code, $e);
+        }
+
+        if (\mb_stripos($message, 'federated_user_id_already_linked') !== false) {
+            return new ProviderLinkFailed('This credential is already associated with a different user account.', $code, $e);
         }
 
         return new AuthError($message, $code, $e);


### PR DESCRIPTION
Firebase has a [Link with OAuth credential](https://firebase.google.com/docs/reference/rest/auth#section-link-with-oauth-credential) functionality, what this PR makes possible in this lib.

The main idea is:
1. In the firebase console you enable a login provider: google, twitter, facebook etc
2. The user logs in, which is handled by a different lib
3. On successful login, it is possible to log in the user into firebase with an `id_token` or `access_token`, so the same user can use firebase stuffs

I use google login and it works for me.

Some things to note:
- The endpoint requires a `requestUri` param which is weird. I hardcoded the example `http://localhost`, because without this there is an error, but with this the login still works, so I guess it's not used. This endpoint is usable for log in too and I think this parameter makes sense there, but what I did is not for log in.
- The `postData` param can hold an `id_token` or `access_token` key. For google login both works for me, but in the examples they used the access token more, so I made that the default, but I introduced a bool param to make it possible to work with id token too
- I created constants for the `Provider` class, which I think is good. But the class is marked as internal, so PHPStorm strikes the class name when I want to use it... I don't really understand why its internal.