### PR TITLE
Fatal error: Uncaught TypeError: Argument 1 passed to Kreait\Firebase\Messaging\Topic::fromValue() must be of the type string, int given

### DIFF
--- a/src/Firebase/Messaging/AppInstance.php
+++ b/src/Firebase/Messaging/AppInstance.php
@@ -39,7 +39,7 @@ final class AppInstance implements JsonSerializable
         $subscriptions = [];
 
         foreach ($rawData['rel']['topics'] ?? [] as $topicName => $subscriptionInfo) {
-            $topic = Topic::fromValue($topicName);
+            $topic = Topic::fromValue((string) $topicName);
             $addedAt = DT::toUTCDateTimeImmutable($subscriptionInfo['addDate'] ?? null);
             $subscriptions[] = new TopicSubscription($topic, $registrationToken, $addedAt);
         }


### PR DESCRIPTION
Resolves 

> Fatal error: Uncaught TypeError: Argument 1 passed to Kreait\Firebase\Messaging\Topic::fromValue() must be of the type string, int given, called in /home/public_html/vendor/kreait/firebase-php/src/Firebase/Messaging/AppInstance.php on line 44 and defined in /home/public_html/vendor/kreait/firebase-php/src/Firebase/Messaging/Topic.php:19 Stack trace: #0 /home/public_html/vendor/kreait/firebase-php/src/Firebase/Messaging/AppInstance.php(44): Kreait\Firebase\Messaging\Topic::fromValue(394511638) #1 /home/public_html/TestFiles/1.php(18): Kreait\Firebase\Messaging\AppInstance::fromRawData(Object(Kreait\Firebase\Messaging\RegistrationToken), Array) #2 {main} thrown in /home/public_html/vendor/kreait/firebase-php/src/Firebase/Messaging/Topic.php on line 19


Happens when subscribed topic happens to be a JSON::Decode Integer