### PR TITLE
Multicast send reports improvements

### DIFF
--- a/src/Firebase/Messaging/CloudMessage.php
+++ b/src/Firebase/Messaging/CloudMessage.php
@@ -209,6 +209,11 @@ class CloudMessage implements Message
         return $this->target ? true : false;
     }
 
+    public function  getTarget()
+    {
+        return $this->target;
+    }
+    
     public function jsonSerialize()
     {
         $data = [

--- a/src/Firebase/Messaging/MulticastSendReport.php
+++ b/src/Firebase/Messaging/MulticastSendReport.php
@@ -127,6 +127,11 @@ final class MulticastSendReport implements Countable
         }));
     }
 
+    public function everything(): self
+    {
+        return self::withItems($this->items);
+    }
+
     public function hasFailures(): bool
     {
         return $this->failures()->count() > 0;


### PR DESCRIPTION
In order to use the multicast send report in order to determine invalid tokens, added a method everything() to the MulticastSendReport class, and added getTarget() to the CloudMessage class.  This allows one to iterate $multicastSendReport->everything()->getItems() and use an index to determine the target of the failed messages from the $messages array: $messages[$idx]->getTarget()->value().