### PR TITLE
Apply leeway to all checked timestamps

### DIFF
--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -550,12 +550,8 @@ class Auth
         $verifiedToken = $verifier->verifyIdToken($idToken);
 
         if ($checkIfRevoked) {
-            if (!($sub = $verifiedToken->getClaim('sub', false))) {
-                throw new InvalidToken($verifiedToken, 'The token has no "sub" claim');
-            }
-
             try {
-                $user = $this->getUser($sub);
+                $user = $this->getUser($verifiedToken->getClaim('sub'));
             } catch (Throwable $e) {
                 throw new InvalidToken($verifiedToken, "Error while getting the token's user: {$e->getMessage()}", $e->getCode(), $e);
             }

--- a/src/Firebase/Auth/IdTokenVerifier.php
+++ b/src/Firebase/Auth/IdTokenVerifier.php
@@ -52,6 +52,11 @@ final class IdTokenVerifier implements Verifier
         try {
             $this->verifier->verifyIdToken($token);
 
+            // We're using getClaim() instead of hasClaim() to also check for an empty value
+            if (!($token->getClaim('sub', false))) {
+                throw new InvalidToken($token, 'The token has no "sub" claim');
+            }
+
             return $token;
         } catch (UnknownKey $e) {
             throw $e;

--- a/tests/Unit/Auth/IdTokenVerifierTest.php
+++ b/tests/Unit/Auth/IdTokenVerifierTest.php
@@ -39,6 +39,7 @@ final class IdTokenVerifierTest extends TestCase
     protected function setUp()
     {
         $this->token = $this->prophesize(Token::class);
+        $this->token->getClaim('sub', Argument::any())->willReturn('sub');
         $this->baseVerifier = $this->prophesize(Verifier::class);
         $this->clock = new FrozenClock(new DateTimeImmutable());
 
@@ -151,6 +152,28 @@ final class IdTokenVerifierTest extends TestCase
 
         $verifier->verifyIdToken($revealedToken);
         $this->addToAssertionCount(1);
+    }
+
+    /** @test */
+    public function it_rejects_an_empty_sub()
+    {
+        $this->token->getClaim('sub', Argument::any())->willReturn(''); // empty claim
+        $revealedToken = $this->token->reveal();
+        $this->baseVerifier->verifyIdToken($revealedToken)->willReturn($revealedToken);
+
+        $this->expectException(InvalidToken::class);
+        $this->verifier->verifyIdToken($revealedToken);
+    }
+
+    /** @test */
+    public function it_rejects_a_missing_sub()
+    {
+        $this->token->getClaim('sub', false)->willReturn(false); // missing claim
+        $revealedToken = $this->token->reveal();
+        $this->baseVerifier->verifyIdToken($revealedToken)->willReturn($revealedToken);
+
+        $this->expectException(InvalidToken::class);
+        $this->verifier->verifyIdToken($revealedToken);
     }
 
     public function it_requires_an_expiration_date()

--- a/tests/Unit/AuthTest.php
+++ b/tests/Unit/AuthTest.php
@@ -114,21 +114,6 @@ final class AuthTest extends UnitTestCase
         $this->assertSame($token, $verifiedToken);
     }
 
-    public function testFailIfNoSubClaim()
-    {
-        $tokenProphecy = $this->prophesize(Token::class);
-        $tokenProphecy->getClaim('sub', Argument::cetera())->willReturn(false);
-        $tokenProphecy->getClaim('auth_time')->willReturn(\date('U'));
-
-        $token = $tokenProphecy->reveal();
-
-        $this->idTokenVerifier->method('verifyIdToken')->with($token)->willReturn($token);
-
-        $this->expectException(InvalidToken::class);
-        $this->expectExceptionMessageRegExp('/sub/i');
-        $this->auth->verifyIdToken($token, true);
-    }
-
     public function testFailIfUserHasBeenDeletedInTheMeantime()
     {
         $uid = 'uid';


### PR DESCRIPTION
Fixes #377 

The "validSince" field on a user record marks the boundary before which Firebase ID tokens are considered revoked. This value is compared to the "auth_time" claim of a given ID token.

Until now, we applied the leeway to the "auth_time" value, but not to the "validSince" value, which means that, if both would contain the value `300`, the auth_time would be modified to `0`, but validSince would remain `300`, resulting in the token being considered revoked although it's not.

### How to test

Add/replace in your project's `composer.json` in the `require` section:

```
"kreait/firebase-php": "dev-verification-leeway"
```

:octocat: 