### PR TITLE
Evaluate unevaluated line breaks in private keys

### DIFF
--- a/src/Firebase/ServiceAccount.php
+++ b/src/Firebase/ServiceAccount.php
@@ -97,7 +97,7 @@ class ServiceAccount
     public function withPrivateKey(string $value): self
     {
         $serviceAccount = clone $this;
-        $serviceAccount->privateKey = $value;
+        $serviceAccount->privateKey = \str_replace('\n', "\n", $value);
 
         return $serviceAccount;
     }


### PR DESCRIPTION
Sometimes the private key that include a new line inside of it was taking the new line and converting the new line to \n which was causing private key error
This way it will always replace the \n with a new line