### PR TITLE
Fixing wrong URL and changed param to string

### DIFF
--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -51,10 +51,10 @@ class ApiClient implements ClientInterface
      * @throws AuthException
      * @throws FirebaseException
      */
-    public function exchangeCustomTokenForIdAndRefreshToken(Token $token): ResponseInterface
+    public function exchangeCustomTokenForIdAndRefreshToken($token): ResponseInterface
     {
-        return $this->requestApi('verifyCustomToken', [
-            'token' => (string) $token,
+        return $this->requestApi('https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken', [
+            'token' => $token instanceof Token ? (string) $token : $token,
             'returnSecureToken' => true,
         ]);
     }


### PR DESCRIPTION
Fixed Wrong url on this method
change param to string to permit an string containing an customToken to be passed to this method.

This commit fixes this
 method to work with updated to the last google Documentation [see google docs reference](https://firebase.google.com/docs/reference/rest/auth/#section-verify-custom-token)