### PR TITLE
Delete email attribute

### DIFF
--- a/src/Firebase/Request/UpdateUser.php
+++ b/src/Firebase/Request/UpdateUser.php
@@ -13,6 +13,7 @@ final class UpdateUser implements Request
 {
     public const DISPLAY_NAME = 'DISPLAY_NAME';
     public const PHOTO_URL = 'PHOTO_URL';
+    public const EMAIL = 'EMAIL';
 
     use EditUserTrait;
 
@@ -55,6 +56,10 @@ final class UpdateUser implements Request
                 case 'removedisplayname':
                     $request = $request->withRemovedDisplayName();
                     break;
+                case 'deleteemail':
+                case 'removeemail':
+                    $request = $request->withRemovedEmail();
+                    break;
 
                 case 'deleteattribute':
                 case 'deleteattributes':
@@ -66,6 +71,9 @@ final class UpdateUser implements Request
                             case 'photo':
                             case 'photourl':
                                 $request = $request->withRemovedPhotoUrl();
+                                break;
+                            case 'email':
+                                $request = $request->withRemovedEmail();
                                 break;
                         }
                     }
@@ -135,6 +143,15 @@ final class UpdateUser implements Request
         $request = clone $this;
         $request->photoUrl = null;
         $request->attributesToDelete[] = self::PHOTO_URL;
+
+        return $request;
+    }
+
+    public function withRemovedEmail(): self
+    {
+        $request = clone $this;
+        $request->email = null;
+        $request->attributesToDelete[] = self::EMAIL;
 
         return $request;
     }

--- a/tests/Integration/AuthTest.php
+++ b/tests/Integration/AuthTest.php
@@ -552,4 +552,22 @@ class AuthTest extends IntegrationTestCase
         $this->expectException(FailedToSignIn::class);
         $this->auth->signInWithIdpIdToken('google.com', 'invalid', 'http://localhost');
     }
+
+    public function testRemoveEmailFromUser(): void
+    {
+        $user = $this->createUserWithEmailAndPassword();
+
+        try {
+            $this->assertNotNull($user->email);
+
+            $userWithoutEmail = $this->auth->updateUser($user->uid, [
+                'deleteEmail' => true,
+            ]);
+
+            $this->assertNull($userWithoutEmail->email);
+            $this->assertFalse($userWithoutEmail->emailVerified);
+        } finally {
+            $this->deleteUser($user);
+        }
+    }
 }

--- a/tests/Unit/Request/UpdateUserTest.php
+++ b/tests/Unit/Request/UpdateUserTest.php
@@ -82,6 +82,22 @@ class UpdateUserTest extends TestCase
                 $expected + ['deleteAttribute' => [UpdateUser::DISPLAY_NAME]],
             ],
             [
+                $given + ['deleteAttribute' => 'email'],
+                $expected + ['deleteAttribute' => [UpdateUser::EMAIL]],
+            ],
+            [
+                $given + ['deleteEmail' => true],
+                $expected + ['deleteAttribute' => [UpdateUser::EMAIL]],
+            ],
+            [
+                $given + ['removeEmail' => true],
+                $expected + ['deleteAttribute' => [UpdateUser::EMAIL]],
+            ],
+            [
+                $given + ['deleteEmail' => true],
+                $expected + ['deleteAttribute' => [UpdateUser::EMAIL]],
+            ],
+            [
                 $given + ['deletephone' => true],
                 $expected + ['deleteProvider' => ['phone']],
             ],


### PR DESCRIPTION
Implementation to solve #459 

As @jeromegamez mentioned in the issue, this is not in de API documentation. However, the firebase api removes the email address from the user and sets emailVerified to false if this method is used.

When a user has a provider that depends on an email address, the provider is deleted. However, I observed with the password provider, that when a (new) email address is set, the provider becomes active again with the same password. Should the password provider be removed when removing the email address? Or should the email not be removable when a password provider is specified?