### PR TITLE
Support Twitter oauth login

### DIFF
--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -212,7 +212,8 @@ class Auth
     {
         return $this->createUser(Request\CreateUser::new()
             ->withUnverifiedEmail($email)
-            ->withClearTextPassword($password));
+            ->withClearTextPassword($password)
+        );
     }
 
     /**
@@ -482,7 +483,7 @@ class Auth
      */
     public function setCustomUserAttributes($uid, array $attributes): UserRecord
     {
-        Deprecation::trigger(__METHOD__, __CLASS__ . '::setCustomUserClaims($uid, $claims)');
+        Deprecation::trigger(__METHOD__, __CLASS__.'::setCustomUserClaims($uid, $claims)');
 
         $this->setCustomUserClaims($uid, $attributes);
 
@@ -500,7 +501,7 @@ class Auth
      */
     public function deleteCustomUserAttributes($uid): UserRecord
     {
-        Deprecation::trigger(__METHOD__, __CLASS__ . '::setCustomUserClaims($uid, null)');
+        Deprecation::trigger(__METHOD__, __CLASS__.'::setCustomUserClaims($uid, null)');
 
         $this->setCustomUserClaims($uid, null);
 
@@ -542,7 +543,7 @@ class Auth
         try {
             return (new Parser())->parse($tokenString);
         } catch (Throwable $e) {
-            throw new InvalidArgumentException('The given token could not be parsed: ' . $e->getMessage());
+            throw new InvalidArgumentException('The given token could not be parsed: '.$e->getMessage());
         }
     }
 
@@ -591,9 +592,9 @@ class Auth
             }
 
             $tokenAuthenticatedAt = DT::toUTCDateTimeImmutable($verifiedToken->getClaim('auth_time'));
-            $tokenAuthenticatedAtWithLeeway = $tokenAuthenticatedAt->modify('-' . $leewayInSeconds . ' seconds');
+            $tokenAuthenticatedAtWithLeeway = $tokenAuthenticatedAt->modify('-'.$leewayInSeconds.' seconds');
 
-            $validSinceWithLeeway = DT::toUTCDateTimeImmutable($validSince)->modify('-' . $leewayInSeconds . ' seconds');
+            $validSinceWithLeeway = DT::toUTCDateTimeImmutable($validSince)->modify('-'.$leewayInSeconds.' seconds');
 
             if ($tokenAuthenticatedAtWithLeeway < $validSinceWithLeeway) {
                 throw new RevokedIdToken($verifiedToken);
@@ -778,7 +779,7 @@ class Auth
      *
      * @throws FailedToSignIn
      */
-    public function signInWithIdpAccessToken($provider, string $accessToken, string $oauthTokenSecret = null, $redirectUrl = null): SignInResult
+    public function signInWithIdpAccessToken($provider, string $accessToken, $redirectUrl = null, ?string $oauthTokenSecret = null): SignInResult
     {
         $provider = $provider instanceof Provider ? (string) $provider : $provider;
         $redirectUrl = $redirectUrl ?? 'http://localhost';

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -212,8 +212,7 @@ class Auth
     {
         return $this->createUser(Request\CreateUser::new()
             ->withUnverifiedEmail($email)
-            ->withClearTextPassword($password)
-        );
+            ->withClearTextPassword($password));
     }
 
     /**
@@ -483,7 +482,7 @@ class Auth
      */
     public function setCustomUserAttributes($uid, array $attributes): UserRecord
     {
-        Deprecation::trigger(__METHOD__, __CLASS__.'::setCustomUserClaims($uid, $claims)');
+        Deprecation::trigger(__METHOD__, __CLASS__ . '::setCustomUserClaims($uid, $claims)');
 
         $this->setCustomUserClaims($uid, $attributes);
 
@@ -501,7 +500,7 @@ class Auth
      */
     public function deleteCustomUserAttributes($uid): UserRecord
     {
-        Deprecation::trigger(__METHOD__, __CLASS__.'::setCustomUserClaims($uid, null)');
+        Deprecation::trigger(__METHOD__, __CLASS__ . '::setCustomUserClaims($uid, null)');
 
         $this->setCustomUserClaims($uid, null);
 
@@ -543,7 +542,7 @@ class Auth
         try {
             return (new Parser())->parse($tokenString);
         } catch (Throwable $e) {
-            throw new InvalidArgumentException('The given token could not be parsed: '.$e->getMessage());
+            throw new InvalidArgumentException('The given token could not be parsed: ' . $e->getMessage());
         }
     }
 
@@ -592,9 +591,9 @@ class Auth
             }
 
             $tokenAuthenticatedAt = DT::toUTCDateTimeImmutable($verifiedToken->getClaim('auth_time'));
-            $tokenAuthenticatedAtWithLeeway = $tokenAuthenticatedAt->modify('-'.$leewayInSeconds.' seconds');
+            $tokenAuthenticatedAtWithLeeway = $tokenAuthenticatedAt->modify('-' . $leewayInSeconds . ' seconds');
 
-            $validSinceWithLeeway = DT::toUTCDateTimeImmutable($validSince)->modify('-'.$leewayInSeconds.' seconds');
+            $validSinceWithLeeway = DT::toUTCDateTimeImmutable($validSince)->modify('-' . $leewayInSeconds . ' seconds');
 
             if ($tokenAuthenticatedAtWithLeeway < $validSinceWithLeeway) {
                 throw new RevokedIdToken($verifiedToken);
@@ -779,7 +778,7 @@ class Auth
      *
      * @throws FailedToSignIn
      */
-    public function signInWithIdpAccessToken($provider, string $accessToken, $redirectUrl = null): SignInResult
+    public function signInWithIdpAccessToken($provider, string $accessToken, string $oauthTokenSecret = null, $redirectUrl = null): SignInResult
     {
         $provider = $provider instanceof Provider ? (string) $provider : $provider;
         $redirectUrl = $redirectUrl ?? 'http://localhost';
@@ -788,7 +787,11 @@ class Auth
             $redirectUrl = (string) $redirectUrl;
         }
 
-        $action = SignInWithIdpCredentials::withAccessToken($provider, $accessToken);
+        if ($oauthTokenSecret) {
+            $action = SignInWithIdpCredentials::withAccessTokenAndOauthTokenSecret($provider, $accessToken, $oauthTokenSecret);
+        } else {
+            $action = SignInWithIdpCredentials::withAccessToken($provider, $accessToken);
+        }
 
         if ($redirectUrl) {
             $action = $action->withRequestUri($redirectUrl);

--- a/src/Firebase/Auth/SignIn/GuzzleHandler.php
+++ b/src/Firebase/Auth/SignIn/GuzzleHandler.php
@@ -83,7 +83,7 @@ final class GuzzleHandler implements Handler
             case $action instanceof SignInWithRefreshToken:
                 return $this->refreshToken($action);
             default:
-                throw new FailedToSignIn(static::class . ' does not support ' . \get_class($action));
+                throw new FailedToSignIn(static::class.' does not support '.\get_class($action));
         }
     }
 

--- a/src/Firebase/Auth/SignIn/GuzzleHandler.php
+++ b/src/Firebase/Auth/SignIn/GuzzleHandler.php
@@ -83,7 +83,7 @@ final class GuzzleHandler implements Handler
             case $action instanceof SignInWithRefreshToken:
                 return $this->refreshToken($action);
             default:
-                throw new FailedToSignIn(static::class.' does not support '.\get_class($action));
+                throw new FailedToSignIn(static::class . ' does not support ' . \get_class($action));
         }
     }
 
@@ -144,12 +144,18 @@ final class GuzzleHandler implements Handler
     {
         $uri = uri_for('https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp');
 
+        $postBody = [
+            'access_token' => $action->accessToken(),
+            'id_token' => $action->idToken(),
+            'providerId' => $action->provider(),
+        ];
+
+        if ($action->oauthTokenSecret()) {
+            $postBody['oauth_token_secret'] = $action->oauthTokenSecret();
+        }
+
         $body = stream_for(\json_encode(\array_merge(self::$defaultBody, [
-            'postBody' => \http_build_query([
-                'access_token' => $action->accessToken(),
-                'id_token' => $action->idToken(),
-                'providerId' => $action->provider(),
-            ]),
+            'postBody' => \http_build_query($postBody),
             'returnIdpCredential' => true,
             'requestUri' => $action->requestUri(),
         ])));

--- a/src/Firebase/Auth/SignInWithIdpCredentials.php
+++ b/src/Firebase/Auth/SignInWithIdpCredentials.php
@@ -36,9 +36,7 @@ final class SignInWithIdpCredentials implements SignIn
 
     public static function withAccessTokenAndOauthTokenSecret(string $provider, string $accessToken, string $oauthTokenSecret): self
     {
-        $instance = new self();
-        $instance->provider = $provider;
-        $instance->accessToken = $accessToken;
+        $instance = self::withAccessToken($provider, $accessToken);
         $instance->oauthTokenSecret = $oauthTokenSecret;
 
         return $instance;

--- a/src/Firebase/Auth/SignInWithIdpCredentials.php
+++ b/src/Firebase/Auth/SignInWithIdpCredentials.php
@@ -15,6 +15,9 @@ final class SignInWithIdpCredentials implements SignIn
     /** @var string */
     private $provider;
 
+    /** @var string|null */
+    private $oauthTokenSecret = null;
+
     /** @var string */
     private $requestUri = 'http://localhost';
 
@@ -27,6 +30,16 @@ final class SignInWithIdpCredentials implements SignIn
         $instance = new self();
         $instance->provider = $provider;
         $instance->accessToken = $accessToken;
+
+        return $instance;
+    }
+
+    public static function withAccessTokenAndOauthTokenSecret(string $provider, string $accessToken, string $oauthTokenSecret): self
+    {
+        $instance = new self();
+        $instance->provider = $provider;
+        $instance->accessToken = $accessToken;
+        $instance->oauthTokenSecret = $oauthTokenSecret;
 
         return $instance;
     }
@@ -51,6 +64,11 @@ final class SignInWithIdpCredentials implements SignIn
     public function provider(): string
     {
         return $this->provider;
+    }
+
+    public function oauthTokenSecret(): ?string
+    {
+        return $this->oauthTokenSecret;
     }
 
     public function accessToken(): ?string


### PR DESCRIPTION
According to [Firebase docs](https://cloud.google.com/identity-platform/docs/reference/rest/v1/accounts/signInWithIdp), OAuth token secret is required to support logging in with Twitter using an OAuth 1.0 credential:

> If the user is signing in to the Twitter provider using a Twitter OAuth 1.0 credential, this should be set to accessToken=[TWITTER_ACCESS_TOKEN]&oauthTokenSecret=[TWITTER_TOKEN_SECRET]&providerId=twitter.com, where [TWITTER_ACCESS_TOKEN] and [TWITTER_TOKEN_SECRET] should be replaced with the Twitter OAuth access token and Twitter OAuth token secret respectively.

This PR adds the ability to specify such a secret when signing in using an IDP access token. Unfortunately there are no tests, but hopefully this will provide the basic implementation for this capability. 