### PR TITLE
feat(auth): Return user email on password reset methods

### DIFF
--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -615,9 +615,13 @@ class Auth
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function verifyPasswordResetCode(string $oobCode): void
+    public function verifyPasswordResetCode(string $oobCode): Email
     {
-        $this->client->verifyPasswordResetCode($oobCode);
+        $response = $this->client->verifyPasswordResetCode($oobCode);
+
+        $email = JSON::decode((string) $response->getBody(), true)['email'] ?? null;
+
+        return new Email($email);
     }
 
     /**
@@ -636,7 +640,7 @@ class Auth
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function confirmPasswordReset(string $oobCode, $newPassword, bool $invalidatePreviousSessions = true): void
+    public function confirmPasswordReset(string $oobCode, $newPassword, bool $invalidatePreviousSessions = true): Email
     {
         $newPassword = $newPassword instanceof ClearTextPassword ? $newPassword : new ClearTextPassword($newPassword);
 
@@ -647,6 +651,8 @@ class Auth
         if ($invalidatePreviousSessions && $email) {
             $this->revokeRefreshTokens($this->getUserByEmail($email)->uid);
         }
+
+        return new Email($email);
     }
 
     /**

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -619,7 +619,7 @@ class Auth
     {
         $response = $this->client->verifyPasswordResetCode($oobCode);
 
-        $email = JSON::decode((string) $response->getBody(), true)['email'] ?? null;
+        $email = JSON::decode((string) $response->getBody(), true)['email'];
 
         return new Email($email);
     }
@@ -646,9 +646,9 @@ class Auth
 
         $response = $this->client->confirmPasswordReset($oobCode, (string) $newPassword);
 
-        $email = JSON::decode((string) $response->getBody(), true)['email'] ?? null;
+        $email = JSON::decode((string) $response->getBody(), true)['email'];
 
-        if ($invalidatePreviousSessions && $email) {
+        if ($invalidatePreviousSessions) {
             $this->revokeRefreshTokens($this->getUserByEmail($email)->uid);
         }
 


### PR DESCRIPTION
In a case where you need to create a custom password reset endpoint and where there is a need for custom logic(related to the local user) that needs to happen after a password reset, currently, there is no way you can connect the local user and Firebase user(without hacking around).

Real-world example:

The user is deactivated(locally) and needs to be activated after the password reset. Because API endpoint(for example), will receive the only oobCode and a new password,  you can't know which user you need to activate without returning email from confirmPasswordReset method or verifyPasswordResetCode(in a case where you want to allow multiple usages of the same code - hopefully not).