### PR TITLE
Add support for RemoteConfig parameter groups

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $finder = PhpCsFixer\Finder::create()
     ->in(['src', 'tests']);
 
@@ -35,6 +37,7 @@ return PhpCsFixer\Config::create()
         'ordered_imports' => true,
         'ordered_interfaces' => true,
         'phpdoc_line_span' => [
+            'const' => 'single',
             'property' => 'single',
         ],
         'phpdoc_no_empty_return' => true,
@@ -46,7 +49,7 @@ return PhpCsFixer\Config::create()
         'php_unit_no_expectation_annotation' => true,
         'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'this'
+            'call_type' => 'this',
         ],
         'phpdoc_align' => false,
         'phpdoc_order' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
   ([Documentation](https://firebase-php.readthedocs.io/en/latest/cloud-messaging.html#topic-management))
   * `Kreait\Firebase\Messaging::subscribeToTopics($topics, $registrationTokenOrTokens)` 
   * `Kreait\Firebase\Messaging::unsubscribeFromTopics($topics, $registrationTokenOrTokens)` 
-  * `Kreait\Firebase\Messaging::unsubscribeFromAllTopics($registrationTokenOrTokens)` 
+  * `Kreait\Firebase\Messaging::unsubscribeFromAllTopics($registrationTokenOrTokens)`
+* The RemoteConfig component now support Parameter Groups.
+  ([Documentation](https://firebase-php.readthedocs.io/en/latest/remote-config.html#parameter-groups))
+   
 ### Changed
   * Replaced usage of deprecated Guzzle helpers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@
   * `Kreait\Firebase\Messaging::unsubscribeFromAllTopics($registrationTokenOrTokens)`
 * The RemoteConfig component now support Parameter Groups.
   ([Documentation](https://firebase-php.readthedocs.io/en/latest/remote-config.html#parameter-groups))
-   
 ### Changed
   * Replaced usage of deprecated Guzzle helpers
+### Deprecated
+  * `Kreait\Firebase\RemoteConfig\Parameter::fromArray()`
+  * `Kreait\Firebase\RemoteConfig\Template::fromResponse()`
 
 ## [5.9.0] - 2020-10-04
 ### Added

--- a/docs/remote-config.rst
+++ b/docs/remote-config.rst
@@ -59,8 +59,6 @@ Get the Remote Config
 .. code-block:: php
 
     $template = $remoteConfig->get(); // Returns a Kreait\Firebase\RemoteConfig\Template
-
-    // Added in 4.29.0
     $version = $template->version(); // Returns a Kreait\Firebase\RemoteConfig\Version
 
 **************************
@@ -95,7 +93,7 @@ Add a parameter
 
     use Kreait\Firebase\RemoteConfig;
 
-    $welcomeMessageParameter = Parameter::named('welcome_message')
+    $welcomeMessageParameter = RemoteConfig\Parameter::named('welcome_message')
             ->withDefaultValue('Welcome!')
             ->withDescription('This is a welcome message') // optional
     ;
@@ -113,7 +111,7 @@ Conditional values
 
     $germanWelcomeMessage = RemoteConfig\ConditionalValue::basedOn($germanLanguageCondition, 'Willkommen!');
 
-    $welcomeMessageParameter = Parameter::named('welcome_message')
+    $welcomeMessageParameter = RemoteConfig\Parameter::named('welcome_message')
             ->withDefaultValue('Welcome!')
             ->withConditionalValue($germanWelcomeMessage);
 
@@ -123,6 +121,23 @@ Conditional values
 
 .. note::
     When you use a conditional value, make sure to add the corresponding condition to the template first.
+
+****************
+Parameter Groups
+****************
+
+.. code-block:: php
+
+    use Kreait\Firebase\RemoteConfig;
+
+    $uiColors = RemoteConfig\ParameterGroup::named('UI Colors')
+        ->withDescription('Remote configurable UI colors')
+        ->withParameter(RemoteConfig\Parameter::named('Primary Color')->withDefaultValue('blue'))
+        ->withParameter(RemoteConfig\Parameter::named('Secondary Color')->withDefaultValue('red'))
+    ;
+
+    $template = $template->withParameterGroup($parameterGroup);
+
 
 **********
 Validation

--- a/src/Firebase/Messaging/MessageTarget.php
+++ b/src/Firebase/Messaging/MessageTarget.php
@@ -12,9 +12,7 @@ final class MessageTarget
     public const TOKEN = 'token';
     public const TOPIC = 'topic';
 
-    /**
-     * @internal
-     */
+    /** @internal */
     public const UNKNOWN = 'unknown';
 
     public const TYPES = [

--- a/src/Firebase/RemoteConfig.php
+++ b/src/Firebase/RemoteConfig.php
@@ -13,6 +13,7 @@ use Kreait\Firebase\RemoteConfig\Template;
 use Kreait\Firebase\RemoteConfig\Version;
 use Kreait\Firebase\RemoteConfig\VersionNumber;
 use Kreait\Firebase\Util\JSON;
+use Psr\Http\Message\ResponseInterface;
 use Traversable;
 
 /**
@@ -39,7 +40,7 @@ class RemoteConfig
      */
     public function get(): Template
     {
-        return Template::fromResponse($this->client->getTemplate());
+        return $this->buildTemplateFromResponse($this->client->getTemplate());
     }
 
     /**
@@ -52,9 +53,7 @@ class RemoteConfig
      */
     public function validate($template): void
     {
-        $template = $template instanceof Template ? $template : Template::fromArray($template);
-
-        $this->client->validateTemplate($template);
+        $this->client->validateTemplate($this->ensureTemplate($template));
     }
 
     /**
@@ -66,9 +65,9 @@ class RemoteConfig
      */
     public function publish($template): string
     {
-        $template = $template instanceof Template ? $template : Template::fromArray($template);
-
-        $etag = $this->client->publishTemplate($template)->getHeader('ETag');
+        $etag = $this->client
+            ->publishTemplate($this->ensureTemplate($template))
+            ->getHeader('ETag');
 
         return \array_shift($etag) ?: '';
     }
@@ -76,16 +75,14 @@ class RemoteConfig
     /**
      * Returns a version with the given number.
      *
-     * @param VersionNumber|mixed $versionNumber
+     * @param VersionNumber|int|string $versionNumber
      *
      * @throws VersionNotFound
      * @throws RemoteConfigException if something went wrong
      */
     public function getVersion($versionNumber): Version
     {
-        $versionNumber = $versionNumber instanceof VersionNumber
-            ? $versionNumber
-            : VersionNumber::fromValue($versionNumber);
+        $versionNumber = $this->ensureVersionNumber($versionNumber);
 
         foreach ($this->listVersions() as $version) {
             if ($version->versionNumber()->equalsTo($versionNumber)) {
@@ -99,20 +96,16 @@ class RemoteConfig
     /**
      * Returns a version with the given number.
      *
-     * @param VersionNumber|mixed $versionNumber
+     * @param VersionNumber|int|string $versionNumber
      *
      * @throws VersionNotFound
      * @throws RemoteConfigException if something went wrong
      */
     public function rollbackToVersion($versionNumber): Template
     {
-        $versionNumber = $versionNumber instanceof VersionNumber
-            ? $versionNumber
-            : VersionNumber::fromValue($versionNumber);
+        $versionNumber = $this->ensureVersionNumber($versionNumber);
 
-        $response = $this->client->rollbackToVersion($versionNumber);
-
-        return Template::fromResponse($response);
+        return $this->buildTemplateFromResponse($this->client->rollbackToVersion($versionNumber));
     }
 
     /**
@@ -144,5 +137,31 @@ class RemoteConfig
 
             $pageToken = $result['nextPageToken'] ?? null;
         } while ($pageToken);
+    }
+
+    /**
+     * @param Template|array<string, mixed> $value
+     */
+    private function ensureTemplate($value): Template
+    {
+        return $value instanceof Template ? $value : Template::fromArray($value);
+    }
+
+    /**
+     * @param VersionNumber|int|string $value
+     */
+    private function ensureVersionNumber($value): VersionNumber
+    {
+        return $value instanceof VersionNumber ? $value : VersionNumber::fromValue($value);
+    }
+
+    private function buildTemplateFromResponse(ResponseInterface $response): Template
+    {
+        $etagHeader = $response->getHeader('ETag');
+        $etag = \array_shift($etagHeader) ?: '*';
+
+        $data = JSON::decode((string) $response->getBody(), true);
+
+        return Template::fromArray($data, $etag);
     }
 }

--- a/src/Firebase/RemoteConfig/Condition.php
+++ b/src/Firebase/RemoteConfig/Condition.php
@@ -44,6 +44,11 @@ class Condition implements \JsonSerializable
         return $this->name;
     }
 
+    public function expression(): string
+    {
+        return $this->expression;
+    }
+
     public function withExpression(string $expression): self
     {
         $condition = clone $this;

--- a/src/Firebase/RemoteConfig/Parameter.php
+++ b/src/Firebase/RemoteConfig/Parameter.php
@@ -92,6 +92,9 @@ class Parameter implements \JsonSerializable
     }
 
     /**
+     * @deprecated 5.10.0
+     * @codeCoverageIgnore
+     *
      * @param array<string, mixed> $data
      */
     public static function fromArray(array $data): self

--- a/src/Firebase/RemoteConfig/ParameterGroup.php
+++ b/src/Firebase/RemoteConfig/ParameterGroup.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+final class ParameterGroup implements \JsonSerializable
+{
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $description = '';
+
+    /** @var Parameter[] */
+    private $parameters = [];
+
+    private function __construct()
+    {
+    }
+
+    public static function named(string $name): self
+    {
+        $group = new self();
+        $group->name = $name;
+
+        return $group;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function description(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return Parameter[]
+     */
+    public function parameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function withDescription(string $description): self
+    {
+        $group = clone $this;
+        $group->description = $description;
+
+        return $group;
+    }
+
+    public function withParameter(Parameter $parameter): self
+    {
+        $group = clone $this;
+        $group->parameters[$parameter->name()] = $parameter;
+
+        return $group;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'description' => $this->description,
+            'parameters' => $this->parameters,
+        ];
+    }
+}

--- a/tests/Integration/RemoteConfigTest.php
+++ b/tests/Integration/RemoteConfigTest.php
@@ -52,6 +52,41 @@ class RemoteConfigTest extends IntegrationTestCase
             },
             "description": "This is a welcome message"
         }
+    },
+    "parameterGroups": {
+        "welcome_messages": {
+            "description": "A group of parameters",
+            "parameters": {
+                "welcome_message_new_users": {
+                    "defaultValue": {
+                        "value": "Welcome, new user!"
+                    },
+                    "conditionalValues": {
+                        "lang_german": {
+                            "value": "Willkommen, neuer Benutzer!"
+                        },
+                        "lang_french": {
+                            "value": "Bienvenu, nouvel utilisateur!"
+                        }
+                    },
+                    "description": "This is a welcome message for new users"
+                },
+                "welcome_message_existing_users": {
+                    "defaultValue": {
+                        "value": "Welcome, existing user!"
+                    },
+                    "conditionalValues": {
+                        "lang_german": {
+                            "value": "Willkommen, bestehender Benutzer!"
+                        },
+                        "lang_french": {
+                            "value": "Bienvenu, utilisant existant!"
+                        }
+                    },
+                    "description": "This is a welcome message for existing users"
+                }
+            }
+        }
     }
 }
 CONFIG;
@@ -70,7 +105,11 @@ CONFIG;
 
         $this->remoteConfig->publish($template);
 
-        $version = $this->remoteConfig->get()->version();
+        $check = $this->remoteConfig->get();
+
+        $this->assertEquals($template->jsonSerialize(), $check->jsonSerialize());
+
+        $version = $check->version();
 
         if (!$version) {
             $this->fail('The template has no version');

--- a/tests/Unit/RemoteConfig/ParameterGroupTest.php
+++ b/tests/Unit/RemoteConfig/ParameterGroupTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
+
+use Kreait\Firebase\RemoteConfig\Parameter;
+use Kreait\Firebase\RemoteConfig\ParameterGroup;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class ParameterGroupTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_be_created(): void
+    {
+        $group = ParameterGroup::named($name = 'name')
+            ->withDescription($description = 'description')
+            ->withParameter($first = Parameter::named('first'))
+            ->withParameter($second = Parameter::named('second'));
+
+        $this->assertSame($name, $group->name());
+        $this->assertSame($description, $group->description());
+
+        $this->assertContains($first, $group->parameters());
+        $this->assertContains($second, $group->parameters());
+    }
+}

--- a/tests/Unit/RemoteConfig/TemplateTest.php
+++ b/tests/Unit/RemoteConfig/TemplateTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
+use Kreait\Firebase\RemoteConfig\Condition;
 use Kreait\Firebase\RemoteConfig\ConditionalValue;
 use Kreait\Firebase\RemoteConfig\Parameter;
+use Kreait\Firebase\RemoteConfig\ParameterGroup;
+use Kreait\Firebase\RemoteConfig\TagColor;
 use Kreait\Firebase\RemoteConfig\Template;
 use Kreait\Firebase\Tests\UnitTestCase;
 
@@ -15,6 +18,16 @@ use Kreait\Firebase\Tests\UnitTestCase;
  */
 class TemplateTest extends UnitTestCase
 {
+    public function testGetDefaultEtag(): void
+    {
+        $this->assertSame('*', Template::new()->etag());
+    }
+
+    public function testDefaultVersionIsNull(): void
+    {
+        $this->assertNull(Template::new()->version());
+    }
+
     public function testCreateWithInvalidConditionalValue(): void
     {
         $parameter = Parameter::named('foo')->withConditionalValue(new ConditionalValue('non_existing_condition', 'false'));
@@ -34,7 +47,51 @@ class TemplateTest extends UnitTestCase
 
         $parameter = Parameter::named('param')->withConditionalValue(ConditionalValue::basedOn('foo'));
 
-        $template->withParameter($parameter);
-        $this->addToAssertionCount(1);
+        $template = $template->withParameter($parameter);
+
+        $condition = $template->conditions()['foo'];
+        $this->assertSame('foo', $condition->name());
+        $this->assertSame('"true"', $condition->expression());
+
+        $this->assertSame('foo', $template->parameters()['param']->conditionalValues()[0]->conditionName());
+    }
+
+    /**
+     * @test
+     */
+    public function testWithFluidConfiguration(): void
+    {
+        $german = Condition::named('lang_german')
+            ->withExpression("device.language in ['de', 'de_AT', 'de_CH']")
+            ->withTagColor(TagColor::ORANGE);
+
+        $french = Condition::named('lang_french')
+            ->withExpression("device.language in ['fr', 'fr_CA', 'fr_CH']")
+            ->withTagColor(TagColor::GREEN);
+
+        $germanWelcomeMessage = ConditionalValue::basedOn($german)->withValue('Willkommen!');
+        $frenchWelcomeMessage = new ConditionalValue('lang_french', 'Bienvenu!');
+
+        $welcomeMessageParameter = Parameter::named('welcome_message')
+            ->withDefaultValue('Welcome!')
+            ->withDescription('This is a welcome message')
+            ->withConditionalValue($germanWelcomeMessage)
+            ->withConditionalValue($frenchWelcomeMessage);
+
+        $uiColors = ParameterGroup::named('ui_colors')
+            ->withDescription('Some colors for the UI')
+            ->withParameter(Parameter::named('primary_color')->withDefaultValue('blue'))
+            ->withParameter(Parameter::named('secondary_color')->withDefaultValue('green'));
+
+        $template = Template::new()
+            ->withCondition($german)
+            ->withCondition($french)
+            ->withParameter($welcomeMessageParameter)
+            ->withParameterGroup($uiColors);
+
+        $this->assertSame($german, $template->conditions()['lang_german']);
+        $this->assertSame($french, $template->conditions()['lang_french']);
+        $this->assertSame($welcomeMessageParameter, $template->parameters()['welcome_message']);
+        $this->assertSame($uiColors, $template->parameterGroups()['ui_colors']);
     }
 }


### PR DESCRIPTION
Closes #483 

Docs: https://github.com/kreait/firebase-php/blob/parameter-groups/docs/remote-config.rst#parameter-groups

```bash
composer require "kreait/firebase-php:dev-parameter-groups"
```

:octocat: 