### PR TITLE
Add support for notification sounds and badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG
 
 ## [Unreleased]
+### Added
+* Added helper methods to add default/specific notification sounds to messages
+  ([Documentation](https://firebase-php.readthedocs.io/en/latest/cloud-messaging.html#notification-sounds))
+  * `Kreait\Firebase\Messaging\ApnsConfig::withDefaultSound()`
+  * `Kreait\Firebase\Messaging\ApnsConfig::withSound($sound)`
+  * `Kreait\Firebase\Messaging\AndroidConfig::withDefaultSound()`
+  * `Kreait\Firebase\Messaging\AndroidConfig::withSound($sound)`
+  * `Kreait\Firebase\Messaging\CloudMessage::withDefaultSounds()`
 
 ## [5.10.0] - 2020-10-20
 ### Added

--- a/docs/cloud-messaging.rst
+++ b/docs/cloud-messaging.rst
@@ -328,6 +328,7 @@ You can find the full Android configuration reference in the official documentat
             'body' => '$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day.',
             'icon' => 'stock_ticker_update',
             'color' => '#f45342',
+            'sound' => 'default',
         ],
     ]);
 
@@ -355,6 +356,7 @@ You can find the full APNs configuration reference in the official documentation
                     'body' => '$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day.',
                 ],
                 'badge' => 42,
+                'sound' => 'default',
             ],
         ],
     ]);
@@ -405,6 +407,31 @@ You can find the full FCM Options configuration reference in the official docume
     ];
 
     $message = $message->withFcmOptions($fcmOptions);
+
+*******************
+Notification Sounds
+*******************
+
+The SDK provides helper methods to add sounds to messages:
+
+* ``CloudMessage::withDefaultSounds()``
+* ``AndroidConfig::withDefaultSound()``
+* ``AndroidConfig::withSound($sound)``
+* ``ApnsConfig::withDefaultSound()``
+* ``ApnsConfig::withSound($sound)``
+
+.. code-block:: php
+
+    $message = CloudMessage::withTarget('token', $token)
+        ->withNotification(['title' => 'Notification title', 'body' => 'Notification body'])
+        ->withDefaultSounds() // Enables default notifications sounds on iOS and Android devices.
+        ->withApnsConfig(
+            ApnsConfig::new()
+                ->withSound('bingbong.aiff')
+                ->withBadge(1)
+        )
+    ;
+
 
 ************
 Using Emojis

--- a/src/Firebase/Messaging/AndroidConfig.php
+++ b/src/Firebase/Messaging/AndroidConfig.php
@@ -6,13 +6,21 @@ namespace Kreait\Firebase\Messaging;
 
 use JsonSerializable;
 
+/**
+ * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidconfig
+ */
 final class AndroidConfig implements JsonSerializable
 {
     /** @var array<string, mixed> */
-    private $rawConfig;
+    private $config;
 
     private function __construct()
     {
+    }
+
+    public static function new(): self
+    {
+        return self::fromArray([]);
     }
 
     /**
@@ -21,7 +29,25 @@ final class AndroidConfig implements JsonSerializable
     public static function fromArray(array $data): self
     {
         $config = new self();
-        $config->rawConfig = $data;
+        $config->config = $data;
+
+        return $config;
+    }
+
+    public function withDefaultSound(): self
+    {
+        return $this->withSound('default');
+    }
+
+    /**
+     * The sound to play when the device receives the notification. Supports "default" or the filename
+     * of a sound resource bundled in the app. Sound files must reside in /res/raw/.
+     */
+    public function withSound(string $sound): self
+    {
+        $config = clone $this;
+        $config->config['notification'] = $config->config['notification'] ?? [];
+        $config->config['notification']['sound'] = $sound;
 
         return $config;
     }
@@ -31,7 +57,7 @@ final class AndroidConfig implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return \array_filter($this->rawConfig, static function ($value) {
+        return \array_filter($this->config, static function ($value) {
             return $value !== null;
         });
     }

--- a/src/Firebase/Messaging/ApnsConfig.php
+++ b/src/Firebase/Messaging/ApnsConfig.php
@@ -6,13 +6,21 @@ namespace Kreait\Firebase\Messaging;
 
 use JsonSerializable;
 
+/**
+ * @see https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
+ */
 final class ApnsConfig implements JsonSerializable
 {
     /** @var array<string, mixed> */
-    private $rawConfig;
+    private $config;
 
     private function __construct()
     {
+    }
+
+    public static function new(): self
+    {
+        return self::fromArray([]);
     }
 
     /**
@@ -21,7 +29,40 @@ final class ApnsConfig implements JsonSerializable
     public static function fromArray(array $data): self
     {
         $config = new self();
-        $config->rawConfig = $data;
+        $config->config = $data;
+
+        return $config;
+    }
+
+    public function withDefaultSound(): self
+    {
+        return $this->withSound('default');
+    }
+
+    /**
+     * The name of a sound file in your app’s main bundle or in the Library/Sounds folder of your app’s
+     * container directory. Specify the string "default" to play the system sound.
+     */
+    public function withSound(string $sound): self
+    {
+        $config = clone $this;
+
+        $config->config['payload'] = $config->config['payload'] ?? [];
+        $config->config['payload']['aps'] = $config->config['payload']['aps'] ?? [];
+        $config->config['payload']['aps']['sound'] = $sound;
+
+        return $config;
+    }
+
+    /**
+     * The number to display in a badge on your app’s icon. Specify 0 to remove the current badge, if any.
+     */
+    public function withBadge(int $number): self
+    {
+        $config = clone $this;
+        $config->config['payload'] = $config->config['payload'] ?? [];
+        $config->config['payload']['aps'] = $config->config['payload']['aps'] ?? [];
+        $config->config['payload']['aps']['badge'] = $number;
 
         return $config;
     }
@@ -31,7 +72,7 @@ final class ApnsConfig implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return \array_filter($this->rawConfig, static function ($value) {
+        return \array_filter($this->config, static function ($value) {
             return $value !== null;
         });
     }

--- a/src/Firebase/Messaging/CloudMessage.php
+++ b/src/Firebase/Messaging/CloudMessage.php
@@ -185,6 +185,18 @@ final class CloudMessage implements Message
         return $new;
     }
 
+    /**
+     * Enables default notifications sounds on iOS and Android devices.
+     */
+    public function withDefaultSounds(): self
+    {
+        $new = clone $this;
+        $new->apnsConfig = ($new->apnsConfig ?: ApnsConfig::new())->withDefaultSound();
+        $new->androidConfig = ($new->androidConfig ?: AndroidConfig::new())->withDefaultSound();
+
+        return $new;
+    }
+
     public function hasTarget(): bool
     {
         return (bool) $this->target;

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -47,6 +47,8 @@ class MessagingTest extends IntegrationTestCase
                     'body' => '$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day.',
                     'icon' => 'stock_ticker_update',
                     'color' => '#f45342',
+                    'sound' => 'default',
+                    'default_sound' => true,
                 ],
                 'fcm_options' => [
                     // https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#fcmoptions
@@ -64,6 +66,7 @@ class MessagingTest extends IntegrationTestCase
                             'title' => '$GOOG up 1.43% on the day',
                             'body' => '$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day.',
                         ],
+                        'sound' => 'default',
                         'badge' => 42,
                     ],
                 ],

--- a/tests/Unit/Messaging/AndroidConfigTest.php
+++ b/tests/Unit/Messaging/AndroidConfigTest.php
@@ -13,9 +13,35 @@ use Kreait\Firebase\Tests\UnitTestCase;
 class AndroidConfigTest extends UnitTestCase
 {
     /**
+     * @test
+     */
+    public function it_is_empty_when_it_is_empty(): void
+    {
+        $this->assertSame('[]', \json_encode(AndroidConfig::new()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_default_sound(): void
+    {
+        $expected = [
+            'notification' => [
+                'sound' => 'default',
+            ],
+        ];
+
+        $this->assertJsonStringEqualsJsonString(
+            \json_encode($expected),
+            \json_encode(AndroidConfig::new()->withDefaultSound())
+        );
+    }
+
+    /**
+     * @test
      * @dataProvider validDataProvider
      */
-    public function testCreateFromArray(array $data): void
+    public function it_can_be_created_from_an_array(array $data): void
     {
         $config = AndroidConfig::fromArray($data);
 

--- a/tests/Unit/Messaging/ApnsConfigTest.php
+++ b/tests/Unit/Messaging/ApnsConfigTest.php
@@ -13,9 +13,56 @@ use Kreait\Firebase\Tests\UnitTestCase;
 class ApnsConfigTest extends UnitTestCase
 {
     /**
+     * @test
+     */
+    public function it_is_empty_when_it_is_empty(): void
+    {
+        $this->assertSame('[]', \json_encode(ApnsConfig::new()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_default_sound(): void
+    {
+        $expected = [
+            'payload' => [
+                'aps' => [
+                    'sound' => 'default',
+                ],
+            ],
+        ];
+
+        $this->assertJsonStringEqualsJsonString(
+            \json_encode($expected),
+            \json_encode(ApnsConfig::new()->withDefaultSound())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_badge(): void
+    {
+        $expected = [
+            'payload' => [
+                'aps' => [
+                    'badge' => 123,
+                ],
+            ],
+        ];
+
+        $this->assertJsonStringEqualsJsonString(
+            \json_encode($expected),
+            \json_encode(ApnsConfig::new()->withBadge(123))
+        );
+    }
+
+    /**
+     * @test
      * @dataProvider validDataProvider
      */
-    public function testCreateFromArray(array $data): void
+    public function it_can_be_created_from_an_array(array $data): void
     {
         $config = ApnsConfig::fromArray($data);
 

--- a/tests/Unit/Messaging/CloudMessageTest.php
+++ b/tests/Unit/Messaging/CloudMessageTest.php
@@ -18,6 +18,11 @@ use PHPUnit\Framework\TestCase;
  */
 class CloudMessageTest extends TestCase
 {
+    public function testEmptyMessage(): void
+    {
+        $this->assertSame('[]', \json_encode(CloudMessage::new()));
+    }
+
     public function testInvalidTargetCausesError(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -64,6 +69,29 @@ class CloudMessageTest extends TestCase
     {
         $this->expectException(InvalidArgument::class);
         CloudMessage::fromArray($data);
+    }
+
+    public function testWithDefaultSounds(): void
+    {
+        $expected = [
+            'android' => [
+                'notification' => [
+                    'sound' => 'default',
+                ],
+            ],
+            'apns' => [
+                'payload' => [
+                    'aps' => [
+                        'sound' => 'default',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertJsonStringEqualsJsonString(
+            \json_encode($expected),
+            \json_encode(CloudMessage::new()->withDefaultSounds()->jsonSerialize())
+        );
     }
 
     public function multipleTargets()


### PR DESCRIPTION
Following a conversation on #454

### Added methods

* `Kreait\Firebase\Messaging\ApnsConfig::withBadge(int $number): self`
* `Kreait\Firebase\Messaging\ApnsConfig::withDefaultSound(): self`
* `Kreait\Firebase\Messaging\ApnsConfig::withSound(string $sound): self`
* `Kreait\Firebase\Messaging\AndroidConfig::withDefaultSound(): self`
* `Kreait\Firebase\Messaging\AndroidConfig::withSound(string $sound): self`
* `Kreait\Firebase\Messaging\CloudMessage::withDefaultSounds(): self`

### How to test

```bash
composer require "kreait/firebase-php:dev-fcm-sounds-and-badges"
```

### Example

```php
$message = CloudMessage::withTarget('token', $token)
    ->withNotification(['title' => 'Notification title', 'body' => 'Notification body'])
    ->withDefaultSounds() // Enables default notifications sounds on iOS and Android devices.
    ->withApnsConfig(
        ApnsConfig::new()
            ->withSound('bingbong.aiff')
            ->withBadge(1)
    )
;
```

### Todo

- [x] Tests
- [x] Documentation 

:octocat: 