### PR TITLE
Add support for Retry-After error response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   * `Kreait\Firebase\Messaging\AndroidConfig::withDefaultSound()`
   * `Kreait\Firebase\Messaging\AndroidConfig::withSound($sound)`
   * `Kreait\Firebase\Messaging\CloudMessage::withDefaultSounds()`
+* Added exception handler for FCM errors concerning quota/rate limits. When a quota is exceeded, a
+  `Kreait\Firebase\Exception\Messaging\QuotaExceeded` exception is thrown. You can get the
+  datetime after which to retry with `Kreait\Firebase\Exception\Messaging\QuotaExceeded::retryAfter()`
+* When the Firebase API is unavailable and/or overloaded, the response might return a `Retry-After`
+  header. When it does, you can get the datetime after which it is suggested to retry with
+  `Kreait\Firebase\Exception\Messaging\ServerUnavailable::retryAfter()`
+
 ### Fixed
   * `Kreait\Firebase\Messaging\CloudMessage::fromArray()` did not allow providing pre-configured message components
     (objects instead of "pure" arrays)

--- a/src/Firebase/Exception/Messaging/QuotaExceeded.php
+++ b/src/Firebase/Exception/Messaging/QuotaExceeded.php
@@ -9,7 +9,7 @@ use Kreait\Firebase\Exception\HasErrors;
 use Kreait\Firebase\Exception\MessagingException;
 use RuntimeException;
 
-final class ServerUnavailable extends RuntimeException implements MessagingException
+final class QuotaExceeded extends RuntimeException implements MessagingException
 {
     use HasErrors;
 

--- a/src/Firebase/Exception/MessagingApiExceptionConverter.php
+++ b/src/Firebase/Exception/MessagingApiExceptionConverter.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\Exception;
 
+use DateTimeImmutable;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use Kreait\Clock;
+use Kreait\Clock\SystemClock;
 use Kreait\Firebase\Exception\Messaging\ApiConnectionFailed;
 use Kreait\Firebase\Exception\Messaging\AuthenticationError;
 use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\MessagingError;
 use Kreait\Firebase\Exception\Messaging\NotFound;
+use Kreait\Firebase\Exception\Messaging\QuotaExceeded;
 use Kreait\Firebase\Exception\Messaging\ServerError;
 use Kreait\Firebase\Exception\Messaging\ServerUnavailable;
 use Kreait\Firebase\Http\ErrorResponseParser;
@@ -25,12 +29,16 @@ class MessagingApiExceptionConverter
     /** @var ErrorResponseParser */
     private $responseParser;
 
+    /** @var Clock */
+    private $clock;
+
     /**
      * @internal
      */
-    public function __construct()
+    public function __construct(?Clock $clock = null)
     {
         $this->responseParser = new ErrorResponseParser();
+        $this->clock = $clock ?? new SystemClock();
     }
 
     /**
@@ -71,11 +79,20 @@ class MessagingApiExceptionConverter
             case 404:
                 $convertedError = new NotFound($message, $code, $previous);
                 break;
+            case 429:
+                $convertedError = new QuotaExceeded($message, $code, $previous);
+                if ($retryAfter = $this->getRetryAfter($response)) {
+                    $convertedError = $convertedError->withRetryAfter($retryAfter);
+                }
+                break;
             case 500:
                 $convertedError = new ServerError($message, $code, $previous);
                 break;
             case 503:
                 $convertedError = new ServerUnavailable($message, $code, $previous);
+                if ($retryAfter = $this->getRetryAfter($response)) {
+                    $convertedError = $convertedError->withRetryAfter($retryAfter);
+                }
                 break;
             default:
                 $convertedError = new MessagingError($message, $code, $previous);
@@ -92,5 +109,28 @@ class MessagingApiExceptionConverter
         }
 
         return new MessagingError($e->getMessage(), $e->getCode(), $e);
+    }
+
+    private function getRetryAfter(ResponseInterface $response): ?DateTimeImmutable
+    {
+        $retryAfter = $response->getHeader('Retry-After')[0] ?? null;
+
+        if (!$retryAfter) {
+            return null;
+        }
+
+        if (\is_numeric($retryAfter)) {
+            return $this->clock->now()->modify("+{$retryAfter} seconds");
+        }
+
+        try {
+            return new DateTimeImmutable($retryAfter);
+        } catch (Throwable $e) {
+            // We can't afford to throw exceptions in an exception handler :)
+            // Here, if the Retry-After header doesn't have a numeric value
+            // or a date that can be handled by DateTimeImmutable, we just
+            // throw it away, sorry not sorry ¯\_(ツ)_/¯
+            return null;
+        }
     }
 }

--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -37,6 +37,7 @@ use Kreait\Firebase\Auth\DisabledLegacyCustomTokenGenerator;
 use Kreait\Firebase\Auth\DisabledLegacyIdTokenVerifier;
 use Kreait\Firebase\Auth\IdTokenVerifier;
 use Kreait\Firebase\Exception\InvalidArgumentException;
+use Kreait\Firebase\Exception\MessagingApiExceptionConverter;
 use Kreait\Firebase\Exception\RuntimeException;
 use Kreait\Firebase\Http\HttpClientOptions;
 use Kreait\Firebase\Http\Middleware;
@@ -467,10 +468,13 @@ class Factory
             throw new RuntimeException('Unable to create the messaging service without a project ID');
         }
 
+        $errorHandler = new MessagingApiExceptionConverter($this->clock);
+
         $messagingApiClient = new Messaging\ApiClient(
             $this->createApiClient([
                 'base_uri' => 'https://fcm.googleapis.com/v1/projects/'.$projectId->value(),
-            ])
+            ]),
+            $errorHandler
         );
 
         $appInstanceApiClient = new Messaging\AppInstanceApiClient(
@@ -479,7 +483,8 @@ class Factory
                 'headers' => [
                     'access_token_auth' => 'true',
                 ],
-            ])
+            ]),
+            $errorHandler
         );
 
         return new Messaging($messagingApiClient, $appInstanceApiClient, $projectId);

--- a/src/Firebase/Messaging/ApiClient.php
+++ b/src/Firebase/Messaging/ApiClient.php
@@ -27,10 +27,10 @@ class ApiClient implements ClientInterface
     /**
      * @internal
      */
-    public function __construct(ClientInterface $client)
+    public function __construct(ClientInterface $client, MessagingApiExceptionConverter $errorHandler)
     {
         $this->client = $client;
-        $this->errorHandler = new MessagingApiExceptionConverter();
+        $this->errorHandler = $errorHandler;
     }
 
     /**

--- a/src/Firebase/Messaging/AppInstanceApiClient.php
+++ b/src/Firebase/Messaging/AppInstanceApiClient.php
@@ -25,10 +25,10 @@ class AppInstanceApiClient
     /**
      * @internal
      */
-    public function __construct(ClientInterface $client)
+    public function __construct(ClientInterface $client, MessagingApiExceptionConverter $errorHandler)
     {
         $this->client = $client;
-        $this->errorHandler = new MessagingApiExceptionConverter();
+        $this->errorHandler = $errorHandler;
     }
 
     /**

--- a/tests/Unit/Exception/MessagingApiExceptionConverterTest.php
+++ b/tests/Unit/Exception/MessagingApiExceptionConverterTest.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\Tests\Unit\Exception;
 
+use DateTimeImmutable;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Kreait\Clock\FrozenClock;
 use Kreait\Firebase\Exception\Messaging\ApiConnectionFailed;
 use Kreait\Firebase\Exception\Messaging\AuthenticationError;
 use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\MessagingError;
 use Kreait\Firebase\Exception\Messaging\NotFound;
+use Kreait\Firebase\Exception\Messaging\QuotaExceeded;
 use Kreait\Firebase\Exception\Messaging\ServerError;
 use Kreait\Firebase\Exception\Messaging\ServerUnavailable;
 use Kreait\Firebase\Exception\MessagingApiExceptionConverter;
@@ -30,9 +33,13 @@ class MessagingApiExceptionConverterTest extends TestCase
     /** @var MessagingApiExceptionConverter */
     private $converter;
 
+    /** @var FrozenClock */
+    private $clock;
+
     protected function setUp(): void
     {
-        $this->converter = new MessagingApiExceptionConverter();
+        $this->clock = new FrozenClock(new DateTimeImmutable());
+        $this->converter = new MessagingApiExceptionConverter($this->clock);
     }
 
     /**
@@ -62,7 +69,7 @@ class MessagingApiExceptionConverterTest extends TestCase
         $this->assertSame($e, $converted->getPrevious());
     }
 
-    public function exceptions()
+    public function exceptions(): array
     {
         return [
             [new ConnectException('Connection Failed', new Request('GET', 'https://domain.tld')), ApiConnectionFailed::class],
@@ -70,6 +77,7 @@ class MessagingApiExceptionConverterTest extends TestCase
             [$this->createRequestException(401, 'Unauthenticated'), AuthenticationError::class],
             [$this->createRequestException(403, 'Unauthorized'), AuthenticationError::class],
             [$this->createRequestException(404, 'Not Found'), NotFound::class],
+            [$this->createRequestException(429, 'Too Many Requests'), QuotaExceeded::class],
             [$this->createRequestException(500, 'Server broken'), ServerError::class],
             [$this->createRequestException(503, 'Server unavailable'), ServerUnavailable::class],
             [$this->createRequestException(418, 'Some tea'), MessagingError::class],
@@ -93,5 +101,50 @@ class MessagingApiExceptionConverterTest extends TestCase
                     'message' => 'Some error that might include the identifier "'.$identifier.'"',
                 ],
             ])));
+    }
+
+    /**
+     * @test
+     */
+    public function it_knows_when_to_retry_after_with_seconds(): void
+    {
+        $response = new Response(429, ['Retry-After' => 60]);
+
+        /** @var QuotaExceeded $converted */
+        $converted = $this->converter->convertResponse($response);
+
+        $expected = $this->clock->now()->modify('+60 seconds');
+
+        $this->assertInstanceOf(QuotaExceeded::class, $converted);
+        $this->assertInstanceOf(DateTimeImmutable::class, $converted->retryAfter());
+        $this->assertSame($expected->getTimestamp(), $converted->retryAfter()->getTimestamp());
+    }
+
+    /**
+     * @test
+     */
+    public function it_knows_when_to_retry_after_with_date_strings(): void
+    {
+        $expected = $this->clock->now()->modify('+60 seconds');
+
+        $response = new Response(503, ['Retry-After' => $expected->format(\DATE_ATOM)]);
+
+        /** @var ServerUnavailable $converted */
+        $converted = $this->converter->convertResponse($response);
+
+        $this->assertInstanceOf(ServerUnavailable::class, $converted);
+        $this->assertInstanceOf(DateTimeImmutable::class, $converted->retryAfter());
+        $this->assertSame($expected->getTimestamp(), $converted->retryAfter()->getTimestamp());
+    }
+
+    public function it_does_not_know_when_to_retry_when_it_does_not_have_to(): void
+    {
+        $response = new Response(503); // no Retry-After
+
+        /** @var ServerUnavailable $converted */
+        $converted = $this->converter->convertResponse($response);
+
+        $this->assertInstanceOf(ServerUnavailable::class, $converted);
+        $this->assertNull($converted->retryAfter());
     }
 }

--- a/tests/Unit/Messaging/ApiClientTest.php
+++ b/tests/Unit/Messaging/ApiClientTest.php
@@ -18,6 +18,7 @@ use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\MessagingError;
 use Kreait\Firebase\Exception\Messaging\ServerError;
 use Kreait\Firebase\Exception\Messaging\ServerUnavailable;
+use Kreait\Firebase\Exception\MessagingApiExceptionConverter;
 use Kreait\Firebase\Exception\MessagingException;
 use Kreait\Firebase\Messaging\ApiClient;
 use PHPUnit\Framework\TestCase;
@@ -42,7 +43,7 @@ class ApiClientTest extends TestCase
             'base_uri' => 'http://example.com',
         ]);
 
-        $this->client = new ApiClient($client);
+        $this->client = new ApiClient($client, new MessagingApiExceptionConverter());
     }
 
     /**

--- a/tests/Unit/MessagingTest.php
+++ b/tests/Unit/MessagingTest.php
@@ -9,6 +9,7 @@ use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\NotFound;
+use Kreait\Firebase\Exception\MessagingApiExceptionConverter;
 use Kreait\Firebase\Messaging;
 use Kreait\Firebase\Messaging\ApiClient;
 use Kreait\Firebase\Messaging\AppInstanceApiClient;
@@ -30,6 +31,9 @@ class MessagingTest extends UnitTestCase
     /** @var AppInstanceApiClient&MockObject */
     private $appInstanceApi;
 
+    /** @var MessagingApiExceptionConverter&MockObject */
+    private $errorHandler;
+
     /** @var Messaging */
     private $messaging;
 
@@ -37,6 +41,7 @@ class MessagingTest extends UnitTestCase
     {
         $this->messagingApi = $this->createMock(ApiClient::class);
         $this->appInstanceApi = $this->createMock(AppInstanceApiClient::class);
+        $this->errorHandler = $this->createMock(MessagingApiExceptionConverter::class);
 
         $this->messaging = new Messaging($this->messagingApi, $this->appInstanceApi, ProjectId::fromString('project-id'));
     }
@@ -44,7 +49,7 @@ class MessagingTest extends UnitTestCase
     public function testDetermineProjectIdFromClientConfig(): void
     {
         $httpClient = new Client(['base_uri' => 'https://fcm.googleapis.com/v1/projects/project-id']);
-        $apiClient = new ApiClient($httpClient);
+        $apiClient = new ApiClient($httpClient, $this->errorHandler);
 
         new Messaging($apiClient, $this->appInstanceApi);
         $this->addToAssertionCount(1);


### PR DESCRIPTION
A proposal to handle #491 

### Changes

- Added `Kreait\Firebase\Exception\Messaging\QuotaExceeded` for `429` HTTP errors
- Added a `retryAfter(): DateTimeImmutable` method to `QuotaExceeded` (429) and `ServerUnavailable` (503) exceptions. This method can return the date and time after which it is recommended to retry a failed request *if* the `Retry-After` response header is set. If it is not set, `retryAfter()` returns `null`

### How to test

```bash
composer require "kreait/firebase-php:retry-after"
```
and cause into rate limits 😅 

### To do

- [ ] Docs

:octocat: 
