### PR TITLE
Make ApiClient tenant aware 

### DIFF
--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -907,7 +907,7 @@ class Auth
         return $this->getUser($uid);
     }
 
-    public function setTenantId($tenantId)
+    public function setTenantId(string $tenantId): Auth
     {
         $this->client->setTenantId($tenantId);
 

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -906,4 +906,11 @@ class Auth
 
         return $this->getUser($uid);
     }
+
+    public function setTenantId($tenantId)
+    {
+        $this->client->setTenantId($tenantId);
+
+        return $this;
+    }
 }

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -29,6 +29,9 @@ class ApiClient implements ClientInterface
     /** @var AuthApiExceptionConverter */
     private $errorHandler;
 
+    /** @var String */
+    private $tenantId;
+
     /**
      * @internal
      */
@@ -206,6 +209,12 @@ class ApiClient implements ClientInterface
             $data = (object) []; // Will be '{}' instead of '[]' when JSON encoded
         }
 
+        if ($this->hasTenantId()) {
+            $data = array_merge($data, [
+                'tenantId' => $this->tenantId,
+            ]);
+        }
+
         $options = \array_filter([
             'json' => $data,
             'headers' => $headers,
@@ -216,5 +225,17 @@ class ApiClient implements ClientInterface
         } catch (Throwable $e) {
             throw $this->errorHandler->convertException($e);
         }
+    }
+
+    public function setTenantId($tenantId)
+    {
+        $this->tenantId = $tenantId;
+
+        return $this;
+    }
+
+    private function hasTenantId()
+    {
+        return ! empty($this->tenantId);
     }
 }

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -227,14 +227,14 @@ class ApiClient implements ClientInterface
         }
     }
 
-    public function setTenantId($tenantId)
+    public function setTenantId(string $tenantId): ApiClient
     {
         $this->tenantId = $tenantId;
 
         return $this;
     }
 
-    private function hasTenantId()
+    private function hasTenantId(): bool
     {
         return ! empty($this->tenantId);
     }

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -210,7 +210,7 @@ class ApiClient implements ClientInterface
         }
 
         if ($this->hasTenantId()) {
-            $data = array_merge($data, [
+            $data = \array_merge($data, [
                 'tenantId' => $this->tenantId,
             ]);
         }
@@ -236,6 +236,6 @@ class ApiClient implements ClientInterface
 
     private function hasTenantId(): bool
     {
-        return ! empty($this->tenantId);
+        return !empty($this->tenantId);
     }
 }

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -29,7 +29,7 @@ class ApiClient implements ClientInterface
     /** @var AuthApiExceptionConverter */
     private $errorHandler;
 
-    /** @var String */
+    /** @var string */
     private $tenantId;
 
     /**


### PR DESCRIPTION
Working on fix for https://github.com/kreait/firebase-php/issues/394

I am aware we should have discussed this before adding the pull request but my current development requires my project to be tenant aware and i needed a solution so what do you think ? 

My inspiration was from the [docs](https://cloud.google.com/identity-platform/docs/multi-tenancy-authentication) itself where from the JS sdk they set tnenat like this 
```javascript
firebase.auth().tenantId = 'TENANT_ID';
```

so i thought we can hava similar approach by calling 

```php

$auth.setTenantId($tenantId)
```

or even quicker with laravel `app()` 

```php
app('firebase.auth')->setTenantId($tenantId);
```

and this method will add the required 'tenantId' parameter to the body sent to requests in `requestApi` of `ApiClient`