### PR TITLE
Include the sent message in a SendReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Unreleased
 ### Added
+* Single reports of a `MulticastSendReport` now include the sent message, in addition to the response.
 * It is now possible to validate multiple messages at once by adding a parameter to the `send*` Methods
   ([Documentation](https://firebase-php.readthedocs.io/en/latest/cloud-messaging.html#validating-messages))
 * It is now possible to check a list of registration tokens whether they are valid and known, unknown, or invalid
   ([Documentation](https://firebase-php.readthedocs.io/en/latest/cloud-messaging.html#validating-registration-tokens))
 * Added methods:
   * `Kreait\Firebase\Messaging::validateRegistrationTokens($registrationTokenOrTokens)`
+### Deprecated
+* `Kreait\Firebase\Http\Requests::findBy()`
+* `Kreait\Firebase\Messaging\MulticastSendReport::withAdded()`
 
 ## [5.13.0] - 2020-12-10
 

--- a/src/Firebase/Http/Requests.php
+++ b/src/Firebase/Http/Requests.php
@@ -21,11 +21,29 @@ final class Requests implements IteratorAggregate
         $this->requests = $requests;
     }
 
+    /**
+     * @deprecated 5.14.0
+     */
     public function findBy(callable $callable): ?RequestInterface
     {
         $results = \array_filter($this->requests, $callable);
 
         return \array_shift($results) ?: null;
+    }
+
+    public function findByContentId(string $contentId): ?RequestInterface
+    {
+        foreach ($this->requests as $request) {
+            $contentIdHeader = $request->getHeaderLine('Content-ID');
+            $contentIdHeaderParts = \explode('-', $contentIdHeader);
+            $requestContentId = \array_pop($contentIdHeaderParts);
+
+            if ($contentId === $requestContentId) {
+                return $request;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Firebase/Messaging.php
+++ b/src/Firebase/Messaging.php
@@ -285,12 +285,6 @@ class Messaging
             return $message;
         }
 
-        if (!\is_array($message)) {
-            throw new InvalidArgumentException(
-                'Unsupported message type. Use an array or a class implementing %s'.Message::class
-            );
-        }
-
         return CloudMessage::fromArray($message);
     }
 

--- a/src/Firebase/Messaging/Http/Request/MessageRequest.php
+++ b/src/Firebase/Messaging/Http/Request/MessageRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Messaging\Http\Request;
+
+use Kreait\Firebase\Messaging\Message;
+
+interface MessageRequest
+{
+    public function message(): Message;
+}

--- a/src/Firebase/Messaging/Http/Request/SendMessage.php
+++ b/src/Firebase/Messaging/Http/Request/SendMessage.php
@@ -10,9 +10,12 @@ use Kreait\Firebase\Http\WrappedPsr7Request;
 use Kreait\Firebase\Messaging\Message;
 use Psr\Http\Message\RequestInterface;
 
-final class SendMessage implements RequestInterface
+final class SendMessage implements MessageRequest, RequestInterface
 {
     use WrappedPsr7Request;
+
+    /** @var Message */
+    private $message;
 
     public function __construct(string $projectId, Message $message, bool $validateOnly = false)
     {
@@ -24,5 +27,11 @@ final class SendMessage implements RequestInterface
         ];
 
         $this->wrappedRequest = new Request('POST', $uri, $headers, $body);
+        $this->message = $message;
+    }
+
+    public function message(): Message
+    {
+        return $this->message;
     }
 }

--- a/src/Firebase/Messaging/Http/Request/ValidateMessage.php
+++ b/src/Firebase/Messaging/Http/Request/ValidateMessage.php
@@ -13,9 +13,12 @@ use Psr\Http\Message\RequestInterface;
 /**
  * @deprecated 5.14.0 use {@see SendMessage} instead
  */
-final class ValidateMessage implements RequestInterface
+final class ValidateMessage implements MessageRequest, RequestInterface
 {
     use WrappedPsr7Request;
+
+    /** @var Message */
+    private $message;
 
     public function __construct(string $projectId, Message $message)
     {
@@ -27,5 +30,11 @@ final class ValidateMessage implements RequestInterface
         ];
 
         $this->wrappedRequest = new Request('POST', $uri, $headers, $body);
+        $this->message = $message;
+    }
+
+    public function message(): Message
+    {
+        return $this->message;
     }
 }

--- a/src/Firebase/Messaging/SendReport.php
+++ b/src/Firebase/Messaging/SendReport.php
@@ -16,6 +16,9 @@ final class SendReport
     /** @var array<mixed>|null */
     private $result;
 
+    /** @var Message|null */
+    private $message;
+
     /** @var Throwable|null */
     private $error;
 
@@ -26,20 +29,22 @@ final class SendReport
     /**
      * @param array<mixed> $response
      */
-    public static function success(MessageTarget $target, array $response): self
+    public static function success(MessageTarget $target, array $response, ?Message $message = null): self
     {
         $report = new self();
         $report->target = $target;
         $report->result = $response;
+        $report->message = $message;
 
         return $report;
     }
 
-    public static function failure(MessageTarget $target, Throwable $error): self
+    public static function failure(MessageTarget $target, Throwable $error, ?Message $message = null): self
     {
         $report = new self();
         $report->target = $target;
         $report->error = $error;
+        $report->message = $message;
 
         return $report;
     }
@@ -87,5 +92,10 @@ final class SendReport
     public function error(): ?Throwable
     {
         return $this->error;
+    }
+
+    public function message(): ?Message
+    {
+        return $this->message;
     }
 }

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -216,6 +216,13 @@ class MessagingTest extends IntegrationTestCase
 
         $this->assertCount(3, $report->successes());
         $this->assertCount(2, $report->failures());
+
+        $allReports = $report->getItems();
+        $this->assertSame($tokenMessage, $allReports[0]->message());
+        $this->assertSame($topicMessage, $allReports[1]->message());
+        $this->assertSame($conditionMessage, $allReports[2]->message());
+        $this->assertSame($invalidToken, $allReports[3]->message());
+        $this->assertSame($invalidMessage, $allReports[4]->message());
     }
 
     public function testValidateRegistrationTokens(): void


### PR DESCRIPTION
Addresses #495 

```bash
composer require "kreait/firebase-php:dev-map-report-to-message"
```

When processing a `MulticastSendReport` this enables inspecting the sent message, not only a response.

```php
$messages = [
    // Up to 500 items, either objects implementing Kreait\Firebase\Messaging\Message
    // or arrays that can be used to create valid to Kreait\Firebase\Messaging\Cloudmessage instances
];

/** @var Kreait\Firebase\Messaging\MulticastSendReport $sendReport **/
$sendReport = $messaging->sendAll($messages);

foreach ($sendReport as $singleReport) {
    $result = $singleReport->result();
    $message = $singleReport->message(); // Message
}
```

:octocat: 