### PR TITLE
Add support for validating multiple messages and registration tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+### Added
+* It is now possible to validate multiple messages at once by adding a parameter to the `send*` Methods
+  ([Documentation](https://firebase-php.readthedocs.io/en/latest/cloud-messaging.html#validating-messages))
+* It is now possible to check a list of registration tokens whether they are valid and known, unknown, or invalid
+  ([Documentation](https://firebase-php.readthedocs.io/en/latest/cloud-messaging.html#validating-registration-tokens))
+* Added methods:
+  * `Kreait\Firebase\Messaging::validateRegistrationTokens($registrationTokenOrTokens)`
+
 ## [5.13.0] - 2020-12-10
 
 This release ensures compatibility with PHP 8.0

--- a/docs/cloud-messaging.rst
+++ b/docs/cloud-messaging.rst
@@ -530,9 +530,40 @@ error message(s) that the API returned.
 
     try {
         $messaging->validate($message);
+        // or
+        $messaging->send($message, $validateOnly = true);
     } catch (InvalidMessage $e) {
         print_r($e->errors());
     }
+
+You can also use the ``send*`` methods with an additional parameter:
+
+.. code-block:: php
+
+    $validateOnly = true;
+
+    $messaging->send($message, $validateOnly);
+    $messaging->sendMulticast($message, $tokens, $validateOnly);
+    $messaging->sendAll($messages, $validateOnly);
+
+******************************
+Validating Registration Tokens
+******************************
+
+If you have a set of registration tokens that you want to check for validity or if they are still registered
+to your project, you can use the `validateTokens()` method:
+
+.. code-block:: php
+
+    $tokens = [...];
+
+    $result = $messaging->validateRegistrationTokens($tokens);
+
+The result is an array with three keys containing the checked tokens:
+
+* ``valid`` contains all tokens that are valid and registered to the current Firebase project
+* ``unknown`` contains all tokens that are valid, but **not** registered to the current Firebase project
+* ``invalid`` contains all invalid (=malformed) tokens
 
 
 ****************

--- a/src/Firebase/Messaging/Http/Request/SendMessage.php
+++ b/src/Firebase/Messaging/Http/Request/SendMessage.php
@@ -14,10 +14,10 @@ final class SendMessage implements RequestInterface
 {
     use WrappedPsr7Request;
 
-    public function __construct(string $projectId, Message $message)
+    public function __construct(string $projectId, Message $message, bool $validateOnly = false)
     {
         $uri = Utils::uriFor('https://fcm.googleapis.com/v1/projects/'.$projectId.'/messages:send');
-        $body = Utils::streamFor(\json_encode(['message' => $message]));
+        $body = Utils::streamFor(\json_encode(['message' => $message, 'validate_only' => $validateOnly]));
         $headers = [
             'Content-Type' => 'application/json; charset=UTF-8',
             'Content-Length' => $body->getSize(),

--- a/src/Firebase/Messaging/Http/Request/SendMessageToTokens.php
+++ b/src/Firebase/Messaging/Http/Request/SendMessageToTokens.php
@@ -19,7 +19,7 @@ final class SendMessageToTokens implements HasSubRequests, RequestInterface
 
     use WrappedPsr7Request;
 
-    public function __construct(string $projectId, Message $message, RegistrationTokens $registrationTokens)
+    public function __construct(string $projectId, Message $message, RegistrationTokens $registrationTokens, bool $validateOnly = false)
     {
         if ($registrationTokens->count() > self::MAX_AMOUNT_OF_TOKENS) {
             throw new InvalidArgumentException('A multicast message can be sent to a maximum amount of '.self::MAX_AMOUNT_OF_TOKENS.' tokens.');
@@ -36,6 +36,6 @@ final class SendMessageToTokens implements HasSubRequests, RequestInterface
             $messages[] = new RawMessageFromArray($messageData);
         }
 
-        $this->wrappedRequest = new SendMessages($projectId, new Messages(...$messages));
+        $this->wrappedRequest = new SendMessages($projectId, new Messages(...$messages), $validateOnly);
     }
 }

--- a/src/Firebase/Messaging/Http/Request/SendMessages.php
+++ b/src/Firebase/Messaging/Http/Request/SendMessages.php
@@ -18,7 +18,7 @@ final class SendMessages implements HasSubRequests, RequestInterface
 
     use WrappedPsr7Request;
 
-    public function __construct(string $projectId, Messages $messages)
+    public function __construct(string $projectId, Messages $messages, bool $validateOnly = false)
     {
         if ($messages->count() > self::MAX_AMOUNT_OF_MESSAGES) {
             throw new InvalidArgumentException('Only '.self::MAX_AMOUNT_OF_MESSAGES.' can be sent at a time.');
@@ -29,7 +29,7 @@ final class SendMessages implements HasSubRequests, RequestInterface
         $index = 0;
 
         foreach ($messages as $message) {
-            $subRequests[] = (new SendMessage($projectId, $message))
+            $subRequests[] = (new SendMessage($projectId, $message, $validateOnly))
                 // see https://github.com/firebase/firebase-admin-node/blob/master/src/messaging/batch-request.ts#L104
                 ->withHeader('Content-ID', (string) ++$index)
                 ->withHeader('Content-Transfer-Encoding', 'binary')

--- a/src/Firebase/Messaging/Http/Request/ValidateMessage.php
+++ b/src/Firebase/Messaging/Http/Request/ValidateMessage.php
@@ -10,6 +10,9 @@ use Kreait\Firebase\Http\WrappedPsr7Request;
 use Kreait\Firebase\Messaging\Message;
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * @deprecated 5.14.0 use {@see SendMessage} instead
+ */
 final class ValidateMessage implements RequestInterface
 {
     use WrappedPsr7Request;

--- a/src/Firebase/Messaging/MulticastSendReport.php
+++ b/src/Firebase/Messaging/MulticastSendReport.php
@@ -144,6 +144,20 @@ final class MulticastSendReport implements Countable
     }
 
     /**
+     * @return string[]
+     */
+    public function validTokens(): array
+    {
+        return $this->successes()
+            ->filter(static function (SendReport $report) {
+                return $report->target()->type() === MessageTarget::TOKEN;
+            })
+            ->map(static function (SendReport $report) {
+                return $report->target()->value();
+            });
+    }
+
+    /**
      * Returns all provided registration tokens that were not reachable.
      *
      * @return string[]

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -218,6 +218,20 @@ class MessagingTest extends IntegrationTestCase
         $this->assertCount(2, $report->failures());
     }
 
+    public function testValidateRegistrationTokens(): void
+    {
+        $tokens = [
+            $valid = $this->getTestRegistrationToken(),
+            // we don't have an unknown token
+            $invalid = 'invalid',
+        ];
+
+        $result = $this->messaging->validateRegistrationTokens($tokens);
+
+        $this->assertSame($valid, $result['valid'][0]);
+        $this->assertSame($invalid, $result['invalid'][0]);
+    }
+
     public function testSubscribeToTopic(): void
     {
         $token = $this->getTestRegistrationToken();

--- a/tests/Unit/MessagingTest.php
+++ b/tests/Unit/MessagingTest.php
@@ -6,8 +6,6 @@ namespace Kreait\Firebase\Tests\Unit;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Exception\Messaging\InvalidArgument;
-use Kreait\Firebase\Exception\Messaging\InvalidMessage;
-use Kreait\Firebase\Exception\Messaging\NotFound;
 use Kreait\Firebase\Exception\MessagingApiExceptionConverter;
 use Kreait\Firebase\Messaging;
 use Kreait\Firebase\Messaging\ApiClient;
@@ -45,12 +43,6 @@ class MessagingTest extends UnitTestCase
         $this->messaging = new Messaging(ProjectId::fromString('project-id'), $this->messagingApi, $this->appInstanceApi);
     }
 
-    public function testSendInvalidObject(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->messaging->send(new \stdClass());
-    }
-
     public function testSendInvalidArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -75,24 +67,6 @@ class MessagingTest extends UnitTestCase
         $this->messaging->unsubscribeFromTopic('topic', []);
     }
 
-    public function testValidateMessageGivenAnInvalidArgument(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->messaging->validate('string');
-    }
-
-    public function testValidateMessageGivenAnUnknownDeviceToken(): void
-    {
-        $message = CloudMessage::withTarget(Messaging\MessageTarget::TOKEN, 'foo');
-
-        $this->messagingApi
-            ->method('send')
-            ->willThrowException((new NotFound()));
-
-        $this->expectException(InvalidMessage::class);
-        $this->messaging->validate($message);
-    }
-
     public function testItWillNotSendAMessageWithoutATarget(): void
     {
         $message = CloudMessage::new();
@@ -101,12 +75,6 @@ class MessagingTest extends UnitTestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->messaging->send($message);
-    }
-
-    public function testItDoesNotAcceptInvalidMessagesWhenMulticasting(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->messaging->sendMulticast(new \stdClass(), []);
     }
 
     public function testAMulticastMessageCannotBeTooLarge(): void


### PR DESCRIPTION
Addresses  #511

With this, it will be possible to validate up to 500 messages and/or registration tokens for validity at once.

### How to test

```
composer require "kreait/firebase-php: dev-multi-validate"
```

#### Validate registration tokens

```php
$registrationTokens = [/* ... */];

$result = $messaging->validateRegistrationTokens($registrationTokens);
```

The result will be an array with the following format:

```
[
    'valid' => [/* valid tokens that are valid and registered to the current Firebase project */],
    'unknown => [/* valid tokens that are valid, but not registered to the current Firebase project */],
    'invalid' => [/* invalid/malformed tokens*/],
]
```

#### Validate multiple messages

Validating multiple messages has the same limitations as actually sending them (only 500 messages can be checked at a time - if you need to validate more, you need to chunk the items beforehand)

```php
$validateOnly = true;

$messaging->send($message, $validateOnly);
$messaging->sendMulticast($message, $tokens, $validateOnly);
$messaging->sendAll($messages, $validateOnly);
```

:octocat: 