### PR TITLE
Re-vamp SDK configuration and initialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,9 @@
         "google/cloud-firestore": "^1.0 to use the Firestore component"
     },
     "autoload": {
+        "files": [
+            "src/Firebase.php"
+        ],
         "psr-4": {
             "Kreait\\Firebase\\": "src/Firebase"
         }

--- a/src/Firebase.php
+++ b/src/Firebase.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait;
+
+use Kreait\Firebase\Exception\FirebaseError;
+use Kreait\Firebase\Factory;
+use Kreait\Firebase\Project;
+use Kreait\Firebase\Project\Config;
+use Kreait\Firebase\Project\ProjectConfig;
+
+final class Firebase
+{
+    private const DEFAULT_NAME = '[DEFAULT]';
+
+    /** @var array<string, Project> */
+    private $projects = [];
+
+    /**
+     * @throws FirebaseError if a project already exists
+     */
+    public function initializeProject(?Config $config = null, ?string $name = null): Project
+    {
+        $name = $name ?? self::DEFAULT_NAME;
+
+        self::assertNullOrNonEmptyProjectName($name);
+
+        if (\array_key_exists($name, $this->projects)) {
+            if ($name === self::DEFAULT_NAME) {
+                throw new FirebaseError(
+                    'The default Firebase project already exists. This means you called initializeProject()'
+                    .' more than once without providing a project name as the second argument. In most cases'
+                    .' you only need to call `initializeProject()` once. But if you want to initialize'
+                    .' multiple projects, pass a second argument to initializeProject()'
+                    .' to give each project a unique name.'
+                );
+            }
+
+            throw new FirebaseError(
+                'A Firebase project named "'.$name.'" already exists. This means you called initializeProject()'
+                .' more than once with the same project name as the second argument. Make sure you provide a'
+                .' unique name every time you call initializeProject().'
+            );
+        }
+
+        $config = $config ?? ProjectConfig::fromEnvironment();
+
+        $this->projects[$name] = new Project($config, new Factory());
+
+        return $this->projects[$name];
+    }
+
+    /**
+     * @throws FirebaseError if a project doesn't exist
+     */
+    public function project(?string $name = null): Project
+    {
+        $name = $name ?? self::DEFAULT_NAME;
+
+        self::assertNullOrNonEmptyProjectName($name);
+
+        if (!\array_key_exists($name, $this->projects)) {
+            $message = ($name === self::DEFAULT_NAME)
+                ? 'The default Firebase project does not exist.'
+                : 'A Firebase project named "'.$name.'" does not exist.';
+
+            throw new FirebaseError(
+                $message.' Make sure that you call initializeProject() before using'
+                .' any of the Firebase services.');
+        }
+
+        return $this->projects[$name];
+    }
+
+    /**
+     * @throws FirebaseError
+     */
+    private static function assertNullOrNonEmptyProjectName(?string $name = null): void
+    {
+        $message = 'You provided an invalid Firebase project name ("'.$name.'")';
+
+        if (\is_string($name) && \trim($name) === '') {
+            throw new FirebaseError($message.': The project name must be a non-empty string');
+        }
+    }
+}

--- a/src/Firebase/Contract/AuthProvider.php
+++ b/src/Firebase/Contract/AuthProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Contract;
+
+interface AuthProvider
+{
+    public function auth(): Auth;
+}

--- a/src/Firebase/Contract/DatabaseProvider.php
+++ b/src/Firebase/Contract/DatabaseProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Contract;
+
+use Kreait\Firebase\Exception\FirebaseException;
+
+interface DatabaseProvider
+{
+    /**
+     * @throws FirebaseException when the requested database could not be provided
+     */
+    public function database(?string $url = null): Database;
+}

--- a/src/Firebase/Contract/DynamicLinksProvider.php
+++ b/src/Firebase/Contract/DynamicLinksProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Contract;
+
+use Kreait\Firebase\Exception\FirebaseException;
+
+interface DynamicLinksProvider
+{
+    /**
+     * @throws FirebaseException when dynamic links can not be provided for the given domain
+     */
+    public function dynamicLinks(?string $domain = null): DynamicLinks;
+}

--- a/src/Firebase/Contract/FirestoreProvider.php
+++ b/src/Firebase/Contract/FirestoreProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Contract;
+
+interface FirestoreProvider
+{
+    public function firestore(): Firestore;
+}

--- a/src/Firebase/Contract/MessagingProvider.php
+++ b/src/Firebase/Contract/MessagingProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Contract;
+
+interface MessagingProvider
+{
+    public function messaging(): Messaging;
+}

--- a/src/Firebase/Contract/RemoteConfigProvider.php
+++ b/src/Firebase/Contract/RemoteConfigProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Contract;
+
+interface RemoteConfigProvider
+{
+    public function remoteConfig(): RemoteConfig;
+}

--- a/src/Firebase/Contract/StorageProvider.php
+++ b/src/Firebase/Contract/StorageProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Contract;
+
+interface StorageProvider
+{
+    public function storage(): Storage;
+}

--- a/src/Firebase/Exception/FirebaseError.php
+++ b/src/Firebase/Exception/FirebaseError.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Exception;
+
+final class FirebaseError extends \Exception implements FirebaseException
+{
+}

--- a/src/Firebase/Project.php
+++ b/src/Firebase/Project.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase;
+
+use Kreait\Firebase\Contract\Auth;
+use Kreait\Firebase\Contract\AuthProvider;
+use Kreait\Firebase\Contract\Database;
+use Kreait\Firebase\Contract\DatabaseProvider;
+use Kreait\Firebase\Contract\DynamicLinks;
+use Kreait\Firebase\Contract\DynamicLinksProvider;
+use Kreait\Firebase\Contract\Firestore;
+use Kreait\Firebase\Contract\FirestoreProvider;
+use Kreait\Firebase\Contract\Messaging;
+use Kreait\Firebase\Contract\MessagingProvider;
+use Kreait\Firebase\Contract\RemoteConfig;
+use Kreait\Firebase\Contract\RemoteConfigProvider;
+use Kreait\Firebase\Contract\Storage;
+use Kreait\Firebase\Contract\StorageProvider;
+use Kreait\Firebase\Exception\FirebaseError;
+use Kreait\Firebase\Project\Config;
+
+final class Project implements AuthProvider, DatabaseProvider, DynamicLinksProvider, FirestoreProvider, MessagingProvider, RemoteConfigProvider, StorageProvider
+{
+    /** @var Config */
+    private $config;
+
+    /** @var Factory */
+    private $baseFactory;
+
+    /** @var Factory|null */
+    private $configuredFactory;
+
+    /** @var array<string, mixed> */
+    private $cache = [];
+
+    /**
+     * @internal
+     */
+    public function __construct(Config $config, Factory $factory)
+    {
+        $this->config = $config;
+        $this->baseFactory = $factory;
+    }
+
+    public function auth(): Auth
+    {
+        return $this->factory()->createAuth();
+    }
+
+    public function database(?string $url = null): Database
+    {
+        $url = $url ?? $this->config->defaultDatabaseUrl();
+
+        if (!$url) {
+            throw new FirebaseError('No database URL was given and no default database has been configured.');
+        }
+
+        $key = 'database_'.\base64_encode($url);
+
+        if (!isset($this->cache[$key])) {
+            $this->cache[$key] = $this->factory()->withDatabaseUri($url)->createDatabase();
+        }
+
+        return $this->cache[$key];
+    }
+
+    public function dynamicLinks(?string $domain = null): DynamicLinks
+    {
+        $domain = $domain ?? $this->config->defaultDynamicLinksDomain();
+
+        if (!$domain) {
+            throw new FirebaseError('No dynamic links domain was given and no default domain has been configured.');
+        }
+
+        $key = 'dynamic_links_'.\base64_encode($domain);
+
+        if (!isset($this->cache[$key])) {
+            $this->cache[$key] = $this->factory()->createDynamicLinksService($domain);
+        }
+
+        return $this->cache[$key];
+    }
+
+    public function firestore(): Firestore
+    {
+        if (!isset($this->cache['firestore'])) {
+            $this->cache['firestore'] = $this->factory()->createFirestore();
+        }
+
+        return $this->cache['firestore'];
+    }
+
+    public function messaging(): Messaging
+    {
+        if (!isset($this->cache['messaging'])) {
+            $this->cache['messaging'] = $this->factory()->createMessaging();
+        }
+
+        return $this->cache['messaging'];
+    }
+
+    public function remoteConfig(): RemoteConfig
+    {
+        if (!isset($this->cache['remote_config'])) {
+            $this->cache['remote_config'] = $this->factory()->createRemoteConfig();
+        }
+
+        return $this->cache['remote_config'];
+    }
+
+    public function storage(): Storage
+    {
+        if (!isset($this->cache['storage'])) {
+            $this->cache['storage'] = $this->factory()->createStorage();
+        }
+
+        return $this->cache['storage'];
+    }
+
+    private function factory(): Factory
+    {
+        if (!$this->configuredFactory) {
+            $this->configuredFactory = $this->buildFactory();
+        }
+
+        return $this->configuredFactory;
+    }
+
+    private function buildFactory(): Factory
+    {
+        $factory = $this->baseFactory;
+        $config = $this->config;
+
+        if ($serviceAccount = $config->serviceAccount()) {
+            $factory = $factory->withServiceAccount($serviceAccount);
+        }
+
+        return $factory;
+    }
+}

--- a/src/Firebase/Project/Config.php
+++ b/src/Firebase/Project/Config.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Project;
+
+interface Config
+{
+    public function defaultDatabaseUrl(): ?string;
+
+    public function defaultDynamicLinksDomain(): ?string;
+
+    public function serviceAccount(): ?string;
+}

--- a/src/Firebase/Project/ProjectConfig.php
+++ b/src/Firebase/Project/ProjectConfig.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Project;
+
+final class ProjectConfig implements Config
+{
+    private const ENV_PREFIX = 'FIREBASE_';
+    private const ENV_DATABASE_URL = 'DATABASE_URL';
+    private const ENV_DYNAMIC_LINKS_DOMAIN = 'DYNAMIC_LINKS_DOMAIN';
+    private const ENV_SERVICE_ACCOUNT = 'CREDENTIALS';
+
+    /** @var string|null */
+    private $defaultDatabaseUrl;
+
+    /** @var string|null */
+    private $defaultDynamicLinksDomain;
+
+    /** @var string|null */
+    private $serviceAccount;
+
+    private function __construct()
+    {
+    }
+
+    public static function new(): self
+    {
+        return new self();
+    }
+
+    public static function fromEnvironment(?string $prefix = null): self
+    {
+        $prefix = $prefix ?? self::ENV_PREFIX;
+
+        $config = new self();
+
+        if ($serviceAccount = self::getenv($prefix, self::ENV_SERVICE_ACCOUNT)) {
+            $config->serviceAccount = $serviceAccount;
+        }
+
+        if ($databaseUrl = self::getenv($prefix, self::ENV_DATABASE_URL)) {
+            $config->defaultDatabaseUrl = $databaseUrl;
+        }
+
+        if ($dynamicLinksDomain = self::getenv($prefix, self::ENV_DYNAMIC_LINKS_DOMAIN)) {
+            $config->defaultDynamicLinksDomain = $dynamicLinksDomain;
+        }
+
+        return $config;
+    }
+
+    public function defaultDatabaseUrl(): ?string
+    {
+        return $this->defaultDatabaseUrl;
+    }
+
+    public function withDefaultDatabaseUrl(string $defaultDatabaseUrl): self
+    {
+        $config = clone $this;
+        $config->defaultDatabaseUrl = $defaultDatabaseUrl;
+
+        return $config;
+    }
+
+    public function defaultDynamicLinksDomain(): ?string
+    {
+        return $this->defaultDynamicLinksDomain;
+    }
+
+    public function withDefaultDynamicLinksDomain(string $defaultDynamicLinksDomain): self
+    {
+        $config = clone $this;
+        $config->defaultDynamicLinksDomain = $defaultDynamicLinksDomain;
+
+        return $config;
+    }
+
+    public function serviceAccount(): ?string
+    {
+        return $this->serviceAccount;
+    }
+
+    public function withServiceAccount(string $serviceAccount): self
+    {
+        $config = clone $this;
+        $config->serviceAccount = $serviceAccount;
+
+        return $config;
+    }
+
+    private static function getenv(string $prefix, string $name): ?string
+    {
+        $fullName = $prefix.$name;
+
+        $value = $_SERVER[$fullName] ?? $_ENV[$fullName] ?? \getenv($fullName);
+
+        if ($value !== false && $value !== null) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Re-vamp the configuration and initialization part of the SDK based on contracts (interfaces) while keeping the old way to not break BC. This should facilitate testing and be a good preparation to enable support for the Firebase emulator (but I don't want to promise too much).

With this, the Factory is just an internal implementation detail and not the first entrypoint in the SDK

The next major release then will have only the contract-based way of doing things 🤞

### How to test

```
composer require "kreait/firebase-php: dev-contracts"
```

#### When everything is configured via environment variables


```php
use Kreait\Firebase;

$firebase = new Firebase();

$db = $firebase->project()->database();
```

#### Explicit configuration from the environment with partial overrides

```php
$config = Firebase\Project\ProjectConfig::fromEnvironment()
    // we can now override/set additional configuration
    ->withDefaultDatabaseUrl('https://my-first-project.firebaseio.com')
;

$project = $firebase->initializeProject($config);

$db = $project->database();
```

#### Explicit configuration

```php
$config = Firebase\Project\ProjectConfig::new()
    ->withServiceAccount('path/to/service-account.json')
    ->withDefaultDatabaseUrl('https://my-first-project.firebaseio.com')
;

$project = $firebase->initializeProject($config); // Default project

$db = $project->database();
```

#### Multiple projects (no default projects)

```php
$config1 = Firebase\Project\ProjectConfig::new();
$config2 = Firebase\Project\ProjectConfig::new();
$config3 = Firebase\Project\ProjectConfig::new();

$firebase->initializeProject($config1); // Default project
$firebase->initializeProject($config2, 'second');
$firebase->initializeProject($config3, 'third');

$firebase->project()->auth()->getUser('...');
$firebase->project('first')->auth()->getUser('...');
$firebase->project('second')->auth()->getUser('...');
```

#### Multiple realtime databases

```php
$config = Firebase\Project\ProjectConfig::fromEnvironment()
    ->withDefaultDatabaseUrl('https://default-db.firebaseio.com');

$project = $firebase->initializeProject($config);

$project->db()->getReference('/'); // Default database
$project->db('https://other-db-in-same-project.firebaseio.com')->getReference('/');
```


#### Project components

```php
$firebase->project('first')->auth();
$firebase->project('second')->database();
$firebase->project('second')->database('https://second-db-in-second-project.firebaseio.com');
$firebase->project('third')->dynamicLinks(); // Default domain
$firebase->project('third')->dynamicLinks('https://custom.goo.gl');
$firebase->project('fourth')->firestore();
$firebase->project('fifth')->messaging();
$firebase->project('sixth')->remoteConfig();
$firebase->project('seventh')->storage();
$firebase->project('eigth')->whoManagesSoManyFirebaseProjectsInOneApplication();
```

:octocat: 