### PR TITLE
Remove shell prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more information, visit the [Firebase Admin PHP SDK documentation](https://f
 The Firebase Admin PHP SDK is available on Packagist as [`kreait/firebase-php`](https://packagist.org/packages/kreait/firebase-php):
 
 ```bash
-$ composer require kreait/firebase-php
+composer require kreait/firebase-php
 ```
 
 Integrations for Laravel, Lumen and Symfony are available:


### PR DESCRIPTION
An extra character has been removed for easy copying of the composer command