### PR TITLE
set locale on Auth/getEmailActionLink

### DIFF
--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -253,7 +253,7 @@ class Auth implements Contract\Auth
         return DeleteUsersResult::fromRequestAndResponse($request, $response);
     }
 
-    public function getEmailActionLink(string $type, $email, $actionCodeSettings = null): string
+    public function getEmailActionLink(string $type, $email, $actionCodeSettings = null, ?string $locale = null): string
     {
         $email = $email instanceof Email ? $email : new Email($email);
 
@@ -268,7 +268,7 @@ class Auth implements Contract\Auth
         $tenantId = $this->tenantId !== null ? $this->tenantId->toString() : null;
 
         return (new CreateActionLink\GuzzleApiClientHandler($this->httpClient))
-            ->handle(CreateActionLink::new($type, $email, $actionCodeSettings, $tenantId))
+            ->handle(CreateActionLink::new($type, $email, $actionCodeSettings, $tenantId, $locale))
         ;
     }
 
@@ -286,7 +286,7 @@ class Auth implements Contract\Auth
 
         $tenantId = $this->tenantId !== null ? $this->tenantId->toString() : null;
 
-        $createAction = CreateActionLink::new($type, $email, $actionCodeSettings, $tenantId);
+        $createAction = CreateActionLink::new($type, $email, $actionCodeSettings, $tenantId, $locale);
         $sendAction = new SendActionLink($createAction, $locale);
 
         if (\mb_strtolower($type) === 'verify_email') {
@@ -318,9 +318,9 @@ class Auth implements Contract\Auth
         (new SendActionLink\GuzzleApiClientHandler($this->httpClient))->handle($sendAction);
     }
 
-    public function getEmailVerificationLink($email, $actionCodeSettings = null): string
+    public function getEmailVerificationLink($email, $actionCodeSettings = null, ?string $locale = null): string
     {
-        return $this->getEmailActionLink('VERIFY_EMAIL', $email, $actionCodeSettings);
+        return $this->getEmailActionLink('VERIFY_EMAIL', $email, $actionCodeSettings, $locale);
     }
 
     public function sendEmailVerificationLink($email, $actionCodeSettings = null, ?string $locale = null): void
@@ -328,9 +328,9 @@ class Auth implements Contract\Auth
         $this->sendEmailActionLink('VERIFY_EMAIL', $email, $actionCodeSettings, $locale);
     }
 
-    public function getPasswordResetLink($email, $actionCodeSettings = null): string
+    public function getPasswordResetLink($email, $actionCodeSettings = null, ?string $locale = null): string
     {
-        return $this->getEmailActionLink('PASSWORD_RESET', $email, $actionCodeSettings);
+        return $this->getEmailActionLink('PASSWORD_RESET', $email, $actionCodeSettings, $locale);
     }
 
     public function sendPasswordResetLink($email, $actionCodeSettings = null, ?string $locale = null): void
@@ -338,9 +338,9 @@ class Auth implements Contract\Auth
         $this->sendEmailActionLink('PASSWORD_RESET', $email, $actionCodeSettings, $locale);
     }
 
-    public function getSignInWithEmailLink($email, $actionCodeSettings = null): string
+    public function getSignInWithEmailLink($email, $actionCodeSettings = null, ?string $locale = null): string
     {
-        return $this->getEmailActionLink('EMAIL_SIGNIN', $email, $actionCodeSettings);
+        return $this->getEmailActionLink('EMAIL_SIGNIN', $email, $actionCodeSettings, $locale);
     }
 
     public function sendSignInWithEmailLink($email, $actionCodeSettings = null, ?string $locale = null): void

--- a/src/Firebase/Auth/CreateActionLink.php
+++ b/src/Firebase/Auth/CreateActionLink.php
@@ -13,6 +13,7 @@ final class CreateActionLink
     private Email $email;
     private ActionCodeSettings $settings;
     private ?string $tenantId = null;
+    private ?string $locale = null;
 
     private function __construct(string $type, Email $email, ActionCodeSettings $settings)
     {
@@ -21,7 +22,7 @@ final class CreateActionLink
         $this->settings = $settings;
     }
 
-    public static function new(string $type, Email $email, ActionCodeSettings $settings, ?string $tenantId = null): self
+    public static function new(string $type, Email $email, ActionCodeSettings $settings, ?string $tenantId = null, ?string $locale = null): self
     {
         $instance = new self($type, $email, $settings);
         $instance->tenantId = $tenantId;
@@ -47,5 +48,10 @@ final class CreateActionLink
     public function tenantId(): ?string
     {
         return $this->tenantId;
+    }
+
+    public function locale(): ?string
+    {
+        return $this->locale;
     }
 }

--- a/src/Firebase/Auth/CreateActionLink.php
+++ b/src/Firebase/Auth/CreateActionLink.php
@@ -26,6 +26,7 @@ final class CreateActionLink
     {
         $instance = new self($type, $email, $settings);
         $instance->tenantId = $tenantId;
+        $instance->locale = $locale;
 
         return $instance;
     }

--- a/src/Firebase/Auth/CreateActionLink/ApiRequest.php
+++ b/src/Firebase/Auth/CreateActionLink/ApiRequest.php
@@ -31,6 +31,7 @@ final class ApiRequest implements RequestInterface
         $headers = \array_filter([
             'Content-Type' => 'application/json; charset=UTF-8',
             'Content-Length' => (string) $body->getSize(),
+            'X-Firebase-Locale' => $action->locale(),
         ]);
 
         $this->wrappedRequest = new Request('POST', $uri, $headers, $body);


### PR DESCRIPTION
This changes the `lang` query string param of the returned email action link.