### PR TITLE
feat: add getTarget method to CloudMessage class

### DIFF
--- a/src/Firebase/Messaging/CloudMessage.php
+++ b/src/Firebase/Messaging/CloudMessage.php
@@ -282,6 +282,11 @@ final class CloudMessage implements Message
         return (bool) $this->target;
     }
 
+    public function getTarget(): ?MessageTarget
+    {
+        return $this->target;
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Unit/Messaging/CloudMessageTest.php
+++ b/tests/Unit/Messaging/CloudMessageTest.php
@@ -164,4 +164,14 @@ final class CloudMessageTest extends TestCase
             ]],
         ];
     }
+
+    public function testGetTarget()
+    {
+        $message = CloudMessage::new()->withChangedTarget('topic', 'test topic');
+        $target = $message->getTarget();
+
+        $this->assertInstanceOf(MessageTarget::class, $target);
+        $this->assertSame('topic', $target->type());
+        $this->assertSame('test topic', $target->value());
+    }
 }


### PR DESCRIPTION
Hi,

I am building a package around this package, where a developer can set target to `CloudMessage` and my package will be consuming the class instance, but there is no way to retrieve the target.

I have added a method to retrieve the target, this will be a nice addition since there is already a `hasTarget` method is the class.

```php
<?php

$message = CloudMessage::new()->withChangedTarget('topic', 'nice topic');

if($message->hasTarget()) {

 $target = $message->getTarget();
 // do something with target
 
}
```
Thanks.