### PR TITLE
Add bulk remove option for RTDB references

### DIFF
--- a/docs/realtime-database.rst
+++ b/docs/realtime-database.rst
@@ -412,7 +412,15 @@ You can also delete by specifying null as the value for another write operation 
 
     $database->getReference('posts')->set(null);
 
-You can use this technique with ``update()`` to delete multiple children in a single API call.
+You can also delete in bulk passing an array of children to the function:
+
+.. code-block:: php
+
+    $data->getReference('posts')->remove([
+        'post1',
+        'post7',
+        'post15'
+    ]);
 
 *********************
 Database transactions

--- a/docs/realtime-database.rst
+++ b/docs/realtime-database.rst
@@ -412,14 +412,14 @@ You can also delete by specifying null as the value for another write operation 
 
     $database->getReference('posts')->set(null);
 
-You can also delete in bulk passing an array of children to the function:
+You can also delete in bulk using the function ``removeChildren()``:
 
 .. code-block:: php
 
-    $data->getReference('posts')->remove([
-        'post1',
-        'post7',
-        'post15'
+    $data->getReference()->removeChildren([
+        'posts/post1',
+        'user-posts/f55dee9a-dd67-4e78-bd7d-f1b4be157a53/post1',
+        'users/f55dee9a-dd67-4e78-bd7d-f1b4be157a53'
     ]);
 
 *********************

--- a/src/Firebase/Database/Reference.php
+++ b/src/Firebase/Database/Reference.php
@@ -329,19 +329,27 @@ class Reference
     }
 
     /**
-     * Remove the data at this database location.
+     * Remove the data at this database location or at the locations given as an argument.
      *
      * Any data at child locations will also be deleted.
      *
      * @see https://firebase.google.com/docs/reference/js/firebase.database.Reference#remove
      *
+     * @param array|null $values
+     *
      * @throws DatabaseException if the API reported an error
      *
      * @return Reference A new instance for the now empty Reference
      */
-    public function remove(): self
+    public function remove(?array $values = null): self
     {
-        $this->apiClient->remove($this->uri);
+        if (is_null($values)) {
+            $this->apiClient->remove($this->uri);
+        } else {
+            $this->update(
+                array_fill_keys($values, null)
+            );
+        }
 
         return $this;
     }

--- a/src/Firebase/Database/Reference.php
+++ b/src/Firebase/Database/Reference.php
@@ -329,27 +329,42 @@ class Reference
     }
 
     /**
-     * Remove the data at this database location or at the locations given as an argument.
+     * Remove the data at this database location.
      *
      * Any data at child locations will also be deleted.
      *
      * @see https://firebase.google.com/docs/reference/js/firebase.database.Reference#remove
      *
-     * @param array|null $values
-     *
      * @throws DatabaseException if the API reported an error
      *
      * @return Reference A new instance for the now empty Reference
      */
-    public function remove(?array $values = null): self
+    public function remove(): self
     {
-        if (is_null($values)) {
-            $this->apiClient->remove($this->uri);
-        } else {
-            $this->update(
-                array_fill_keys($values, null)
-            );
-        }
+        $this->apiClient->remove($this->uri);
+
+        return $this;
+    }
+
+    /**
+     * Remove the data at the given locations.
+     *
+     * Each location can either be a simple property (for example, "name"), or a relative path
+     * (for example, "name/first") from the current location to the data to remove.
+     *
+     * Any data at child locations will also be deleted.
+     *
+     * @param string[] $keys Locations to remove
+     *
+     * @return Reference
+     *
+     * @throws DatabaseException
+     */
+    public function removeChildren(array $keys): self
+    {
+        $this->update(
+            array_fill_keys($keys, null)
+        );
 
         return $this;
     }

--- a/tests/Integration/Database/ReferenceTest.php
+++ b/tests/Integration/Database/ReferenceTest.php
@@ -81,6 +81,32 @@ final class ReferenceTest extends DatabaseTestCase
         $this->assertEquals(['second' => 'value'], $ref->getValue());
     }
 
+    public function testBulkRemove(): void
+    {
+        $ref = $this->ref->getChild(__FUNCTION__);
+
+        $ref->set([
+            'first' => 'value',
+            'second' => [
+                'first_nested' => 'value',
+                'second_nested' => 'value',
+            ],
+            'third' => 'value',
+        ]);
+
+        $ref->remove([
+            'first',
+            'second/first_nested',
+        ]);
+
+        $this->assertEquals([
+            'second' => [
+                'second_nested' => 'value'
+            ],
+            'third' => 'value',
+        ], $ref->getValue());
+    }
+
     public function testPushToGetKey(): void
     {
         $ref = $this->ref->getChild(__FUNCTION__);

--- a/tests/Integration/Database/ReferenceTest.php
+++ b/tests/Integration/Database/ReferenceTest.php
@@ -81,7 +81,7 @@ final class ReferenceTest extends DatabaseTestCase
         $this->assertEquals(['second' => 'value'], $ref->getValue());
     }
 
-    public function testBulkRemove(): void
+    public function testRemoveChildren(): void
     {
         $ref = $this->ref->getChild(__FUNCTION__);
 
@@ -94,7 +94,7 @@ final class ReferenceTest extends DatabaseTestCase
             'third' => 'value',
         ]);
 
-        $ref->remove([
+        $ref->removeChildren([
             'first',
             'second/first_nested',
         ]);


### PR DESCRIPTION
Hi!

This PR looks to add a more convenient way to remove data in bulk from a database. This is already possible by using `update` with an array with the paths as keys and null as values, which is what this PR does under the hood.

I added an optional argument to the `Reference::remove` method to do so, but maybe it would've been a better idea to create a different `Reference::bulkRemove` method. If you think so, I'm more than willing to change it to your liking.

Of course, feel free to edit anything (or request me to do so) or outright reject the PR if you think it doesn't fit.

Thanks for maintaining the library :)