### PR TITLE
Add support for APNS subtitles (iOS 9+)

### DIFF
--- a/src/Firebase/Messaging/ApnsConfig.php
+++ b/src/Firebase/Messaging/ApnsConfig.php
@@ -115,6 +115,19 @@ final class ApnsConfig implements JsonSerializable
     }
 
     /**
+     * A subtitle of the notification, supported by iOS 9+, silently ignored for others
+     */
+    public function withSubtitle(String $subtitle): self
+    {
+        $config = clone $this;
+        $config->config['payload'] ??= [];
+        $config->config['payload']['aps'] ??= [];
+        $config->config['payload']['aps']['subtitle'] = $subtitle;
+
+        return $config;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function jsonSerialize(): array

--- a/tests/Unit/Messaging/ApnsConfigTest.php
+++ b/tests/Unit/Messaging/ApnsConfigTest.php
@@ -70,6 +70,22 @@ final class ApnsConfigTest extends UnitTestCase
         $this->assertSame('5', $config->jsonSerialize()['headers']['apns-priority']);
     }
 
+    public function testItHasASubtitle(): void
+    {
+        $expected = [
+            'payload' => [
+                'aps' => [
+                    'subtitle' => 'i am a subtitle',
+                ],
+            ],
+        ];
+
+        $this->assertJsonStringEqualsJsonString(
+            \json_encode($expected),
+            \json_encode(ApnsConfig::new()->withSubtitle('i am a subtitle'))
+        );
+    }
+
     /**
      * @return array<string, array<int, array<string, mixed>>>
      */


### PR DESCRIPTION
iOS 9+ has support for subtitles.
![image](https://user-images.githubusercontent.com/1230814/156337962-de451ee8-01a9-4d5e-a613-61db75a66731.png)

This PR allows setting a subtitle in the ApnsConfig object.
