### PR TITLE
word was written twice

### DIFF
--- a/docs/cloud-messaging.rst
+++ b/docs/cloud-messaging.rst
@@ -178,7 +178,7 @@ Each of the Firebase client SDKs are able to generate these registration tokens:
 Send messages to multiple devices (Multicast)
 *********************************************
 
-You can send send one message to up to 500 devices:
+You can send one message to up to 500 devices:
 
 .. code-block:: php
 
@@ -223,7 +223,7 @@ methods to determine the successes and failures of the multicasted message:
 Send multiple messages at once
 ******************************
 
-You can send send up to 500 prepared messages (each message has a token, topic or condition as a target) in one go:
+You can send up to 500 prepared messages (each message has a token, topic or condition as a target) in one go:
 
 .. code-block:: php
 


### PR DESCRIPTION
The word "send" was written twice in a line, making grammatical error, so I removed it.