### PR TITLE
Fix JSON encoding of nested lists

### DIFF
--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -62,7 +62,7 @@ class ApiClient
     {
         return $this->requestApi('https://identitytoolkit.googleapis.com/v1/accounts:update', [
             'localId' => $uid,
-            'customAttributes' => JSON::encode($claims, JSON_FORCE_OBJECT),
+            'customAttributes' => JSON::encode((object) $claims),
         ]);
     }
 


### PR DESCRIPTION
Hi! 

I'm creating this PR because when using the JSON_FORCE_OBJECT param in json_encode function, it also casts to objects all arrays inside it. For example:

[1, 2, 3] will be translated to { '0': 1, '1': 2, '2': 3 }

I'm not sure that this behaviour is expected and in previous versions wasn't performing like this.

Kind regards!
