### PR TITLE
Ensure that FCM messages have processable APNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+* If not already set, APNs configs are enriched with the necessary headers and fields to ensure the delivery of
+  iOS background messages and alerts.
+  * The `apns-push-type` header is set to `background` or `alert`
+  * The `content-available` field is set to `1` in case of a background message
 * FCM Messages are now annotated for better PHPStan/Psalm resolution
 * Added methods
   * `\Kreait\Firebase\Messaging\AndroidConfig::withMinimalNotificationPriority()`
@@ -17,6 +21,13 @@
   * `\Kreait\Firebase\Messaging\AndroidConfig::withPublicNotificationVisibility()`
   * `\Kreait\Firebase\Messaging\AndroidConfig::withSecretNotificationVisibility()`
   * `\Kreait\Firebase\Messaging\AndroidConfig::withNotificationVisibility()`
+  * `\Kreait\Firebase\Messaging\ApnsConfig::data()`
+  * `\Kreait\Firebase\Messaging\ApnsConfig::hasHeader()`
+  * `\Kreait\Firebase\Messaging\ApnsConfig::isAlert()`
+  * `\Kreait\Firebase\Messaging\ApnsConfig::toArray()`
+  * `\Kreait\Firebase\Messaging\ApnsConfig::withApsField()`
+  * `\Kreait\Firebase\Messaging\ApnsConfig::withDataField()`
+  * `\Kreait\Firebase\Messaging\ApnsConfig::withHeader()`
 
 ### Changed
 

--- a/src/Firebase/Messaging.php
+++ b/src/Firebase/Messaging.php
@@ -22,6 +22,8 @@ use Kreait\Firebase\Messaging\Message;
 use Kreait\Firebase\Messaging\Messages;
 use Kreait\Firebase\Messaging\MessageTarget;
 use Kreait\Firebase\Messaging\MulticastSendReport;
+use Kreait\Firebase\Messaging\Processor\SetApnsContentAvailableIfNeeded;
+use Kreait\Firebase\Messaging\Processor\SetApnsPushTypeIfNeeded;
 use Kreait\Firebase\Messaging\RegistrationToken;
 use Kreait\Firebase\Messaging\RegistrationTokens;
 use Kreait\Firebase\Messaging\Topic;
@@ -203,11 +205,12 @@ final class Messaging implements Contract\Messaging
      */
     private function makeMessage($message): Message
     {
-        if ($message instanceof Message) {
-            return $message;
-        }
+        $message = $message instanceof Message ? $message : CloudMessage::fromArray($message);
 
-        return CloudMessage::fromArray($message);
+        $message = (new SetApnsPushTypeIfNeeded())($message);
+        $message = (new SetApnsContentAvailableIfNeeded())($message);
+
+        return $message;
     }
 
     private function messageHasTarget(Message $message): bool

--- a/src/Firebase/Messaging/Notification.php
+++ b/src/Firebase/Messaging/Notification.php
@@ -6,6 +6,13 @@ namespace Kreait\Firebase\Messaging;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
 
+/**
+ * @phpstan-type NotificationShape array{
+ *     title?: string,
+ *     body?: string,
+ *     imageUrl?: string
+ * }
+ */
 final class Notification implements \JsonSerializable
 {
     private ?string $title;

--- a/src/Firebase/Messaging/Processor/SetApnsContentAvailableIfNeeded.php
+++ b/src/Firebase/Messaging/Processor/SetApnsContentAvailableIfNeeded.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Messaging\Processor;
+
+use Beste\Json;
+use Kreait\Firebase\Messaging\ApnsConfig;
+use Kreait\Firebase\Messaging\CloudMessage;
+use Kreait\Firebase\Messaging\Message;
+use Kreait\Firebase\Messaging\MessageData;
+use Kreait\Firebase\Messaging\Notification;
+
+/**
+ * @phpstan-import-type ApnsConfigShape from ApnsConfig
+ * @phpstan-import-type NotificationShape from Notification
+ */
+final class SetApnsContentAvailableIfNeeded
+{
+    public function __invoke(Message $message): Message
+    {
+        $payload = Json::decode(Json::encode($message), true);
+
+        $notification = $this->getNotification($payload);
+        $apnsConfig = $this->getApnsConfig($payload);
+
+        if ($notification !== null || $apnsConfig->isAlert()) {
+            // This is an alert, no 'content-available' field needed
+            return $message;
+        }
+
+        $messageData = $this->getMessageData($payload);
+        $apnsData = $apnsConfig->data();
+
+        $hasData = $messageData->toArray() !== [] || $apnsData !== [];
+
+        if (!$hasData) {
+            // No data, no 'content-available' field
+            return $message;
+        }
+
+        $apnsConfig = $apnsConfig->withApsField('content-available', 1);
+
+        return CloudMessage::fromArray($payload)->withApnsConfig($apnsConfig);
+    }
+
+    /**
+     * @param array<string, array<string, string>> $payload
+     */
+    public function getNotification(array $payload): ?Notification
+    {
+        if (array_key_exists('notification', $payload) && is_array($payload['notification'])) {
+            /** @var NotificationShape $notification */
+            $notification = $payload['notification'];
+
+            return Notification::fromArray($notification);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function getApnsConfig(array $payload): ApnsConfig
+    {
+        if (array_key_exists('apns', $payload) && is_array($payload['apns'])) {
+            /** @var NotificationShape $config */
+            $config = $payload['apns'];
+
+            return ApnsConfig::fromArray($config);
+        }
+
+        return ApnsConfig::new();
+    }
+
+    /**
+     * @param array<string, array<string, string>> $payload
+     */
+    public function getMessageData(array $payload): MessageData
+    {
+        if (array_key_exists('data', $payload) && is_array($payload['data'])) {
+            $messageData = MessageData::fromArray($payload['data']);
+        } else {
+            $messageData = MessageData::fromArray([]);
+        }
+        return $messageData;
+    }
+}

--- a/src/Firebase/Messaging/Processor/SetApnsPushTypeIfNeeded.php
+++ b/src/Firebase/Messaging/Processor/SetApnsPushTypeIfNeeded.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Messaging\Processor;
+
+use Beste\Json;
+use Kreait\Firebase\Messaging\ApnsConfig;
+use Kreait\Firebase\Messaging\CloudMessage;
+use Kreait\Firebase\Messaging\Message;
+use Kreait\Firebase\Messaging\MessageData;
+use Kreait\Firebase\Messaging\Notification;
+
+/**
+ * @phpstan-import-type ApnsConfigShape from ApnsConfig
+ * @phpstan-import-type NotificationShape from Notification
+ */
+final class SetApnsPushTypeIfNeeded
+{
+    public function __invoke(Message $message): Message
+    {
+        $payload = Json::decode(Json::encode($message), true);
+
+        $notification = $this->getNotification($payload);
+        $messageData = $this->getMessageData($payload);
+        $apnsConfig = $this->getApnsConfig($payload);
+        $apnsData = $apnsConfig->data();
+
+        $isAlert = $notification !== null || $apnsConfig->isAlert();
+        $hasData = $messageData->toArray() !== [] || $apnsData !== [];
+        $isBackgroundMessage = !$isAlert && $hasData;
+
+        if (!$isAlert && !$hasData) {
+            return $message;
+        }
+
+        if ($apnsConfig->hasHeader('apns-push-type')) {
+            return $message;
+        }
+
+        if ($isAlert) {
+            $apnsConfig = $apnsConfig->withHeader('apns-push-type', 'alert');
+        } elseif ($isBackgroundMessage) {
+            $apnsConfig = $apnsConfig->withHeader('apns-push-type', 'background');
+        }
+
+        return CloudMessage::fromArray($payload)->withApnsConfig($apnsConfig);
+    }
+
+    /**
+     * @param array<string, array<string, string>> $payload
+     */
+    public function getNotification(array $payload): ?Notification
+    {
+        if (array_key_exists('notification', $payload) && is_array($payload['notification'])) {
+            /** @var NotificationShape $notification */
+            $notification = $payload['notification'];
+
+            return Notification::fromArray($notification);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function getApnsConfig(array $payload): ApnsConfig
+    {
+        if (array_key_exists('apns', $payload) && is_array($payload['apns'])) {
+            /** @var NotificationShape $config */
+            $config = $payload['apns'];
+
+            return ApnsConfig::fromArray($config);
+        }
+
+        return ApnsConfig::new();
+    }
+
+    /**
+     * @param array<string, array<string, string>> $payload
+     */
+    public function getMessageData(array $payload): MessageData
+    {
+        if (array_key_exists('data', $payload) && is_array($payload['data'])) {
+            $messageData = MessageData::fromArray($payload['data']);
+        } else {
+            $messageData = MessageData::fromArray([]);
+        }
+        return $messageData;
+    }
+}

--- a/tests/Unit/Messaging/Processor/SetApnsContentAvailableIfNeededTest.php
+++ b/tests/Unit/Messaging/Processor/SetApnsContentAvailableIfNeededTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\Messaging\Processor;
+
+use Kreait\Firebase\Messaging\ApnsConfig;
+use Kreait\Firebase\Messaging\CloudMessage;
+use Kreait\Firebase\Messaging\Processor\SetApnsContentAvailableIfNeeded;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class SetApnsContentAvailableIfNeededTest extends TestCase
+{
+    private SetApnsContentAvailableIfNeeded $processor;
+
+    protected function setUp(): void
+    {
+        $this->processor = new SetApnsContentAvailableIfNeeded();
+    }
+
+    public function testItDoesNotApplyIfItHasANotification(): void
+    {
+        $input = CloudMessage::new()->withNotification(['title' => 'Title']);
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertMissingContentAvailable($result);
+    }
+
+    public function testItDoesNotApplyIfItHasAnAlert(): void
+    {
+        $input = CloudMessage::new()
+            ->withApnsConfig(
+                ApnsConfig::new()->withSound('default') // sound, badge or alert
+            );
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertMissingContentAvailable($result);
+    }
+
+    public function testItDoesNotApplyWhenItHasNoMessageData(): void
+    {
+        $input = CloudMessage::new();
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertMissingContentAvailable($result);
+    }
+
+    public function testItDoesNotApplyWhenItHasNoDataAtAll(): void
+    {
+        // No message data and no ApnsData
+        $input = CloudMessage::new();
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertMissingContentAvailable($result);
+    }
+
+    public function testItAppliesWithMessageData(): void
+    {
+        $input = CloudMessage::new()->withData(['foo' => 'bar']);
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertContentAvailable($result);
+    }
+
+    public function testItAppliesWithApnsData(): void
+    {
+        $input = CloudMessage::new()
+            ->withApnsConfig(
+                ApnsConfig::new()->withDataField('foo', 'bar')
+            );
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertContentAvailable($result);
+    }
+
+    private function assertContentAvailable(CloudMessage $message): void
+    {
+        $this->assertApsField($message, 'content-available', 1);
+    }
+
+    private function assertMissingContentAvailable(CloudMessage $message): void
+    {
+        $this->assertMissingApsField($message, 'content-available');
+    }
+
+    /**
+     * @param mixed $expected
+     */
+    private function assertApsField(CloudMessage $message, string $name, $expected): void
+    {
+        $config = invade($message)->apnsConfig;
+        assert($config instanceof ApnsConfig);
+
+        $payload = invade($config)->payload;
+        assert(is_array($payload));
+
+        $aps = $payload['aps'] ?? [];
+
+        $this->assertArrayHasKey($name, $aps);
+        $this->assertSame($expected, $aps[$name]);
+    }
+
+    private function assertMissingApsField(CloudMessage $message, string $name): void
+    {
+        $config = invade($message)->apnsConfig;
+        assert($config instanceof ApnsConfig);
+
+        $payload = invade($config)->payload;
+        assert(is_array($payload));
+
+        $aps = $payload['aps'] ?? [];
+
+        $this->assertArrayNotHasKey($name, $aps);
+    }
+}

--- a/tests/Unit/Messaging/Processor/SetApnsPushTypeIfNeededTest.php
+++ b/tests/Unit/Messaging/Processor/SetApnsPushTypeIfNeededTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\Messaging\Processor;
+
+use Kreait\Firebase\Messaging\ApnsConfig;
+use Kreait\Firebase\Messaging\CloudMessage;
+use Kreait\Firebase\Messaging\Processor\SetApnsPushTypeIfNeeded;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class SetApnsPushTypeIfNeededTest extends TestCase
+{
+    private SetApnsPushTypeIfNeeded $processor;
+
+    protected function setUp(): void
+    {
+        $this->processor = new SetApnsPushTypeIfNeeded();
+    }
+
+    public function testItDoesNotOverridePreexistingPushHeaders(): void
+    {
+        $input = CloudMessage::new()
+            ->withNotification(['title' => 'Title']) // This would normally lead to the 'alert' push type
+            ->withApnsConfig(
+                ApnsConfig::new()->withHeader('apns-push-type', $pushType = 'location')
+            );
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertHeader($result, 'apns-push-type', $pushType);
+    }
+
+    public function testAMessageWithoutAnythingOfRelevanceHasNoPushType(): void
+    {
+        $input = CloudMessage::new();
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertMissingHeader($result, 'apns-push-type');
+    }
+
+    public function testABackgroundMessageReceivesAnAccordingPushType(): void
+    {
+        $input = CloudMessage::new()->withData(['foo' => 'bar']);
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertHeader($result, 'apns-push-type', 'background');
+    }
+
+    public function testANotificationMessageReceivesAnAccordingPushType(): void
+    {
+        $input = CloudMessage::new()->withNotification(['title' => 'Title']);
+
+        $result = ($this->processor)($input);
+        assert($result instanceof CloudMessage);
+
+        $this->assertHeader($result, 'apns-push-type', 'alert');
+    }
+
+    /**
+     * @param mixed $expected
+     */
+    private function assertHeader(CloudMessage $message, string $name, $expected): void
+    {
+        $config = invade($message)->apnsConfig;
+        assert($config instanceof ApnsConfig);
+
+        $headers = invade($config)->headers;
+        assert(is_array($headers));
+
+        $this->assertArrayHasKey($name, $headers);
+        $this->assertSame($expected, $headers[$name]);
+    }
+
+    private function assertMissingHeader(CloudMessage $message, string $name): void
+    {
+        $config = invade($message)->apnsConfig;
+        assert($config instanceof ApnsConfig);
+
+        $headers = invade($config)->headers;
+        assert(is_array($headers));
+
+        $this->assertArrayNotHasKey($name, $headers);
+    }
+}


### PR DESCRIPTION
Fixes #700

Changes to APNs configs in FCM messages are applied as follows:

* If the message has a notification and the `apns-push-type` is not already set, it adds the `apns-push-type` header to `alert`
* If the message is a background message (no notification, but with message data)
  * and the `apns-push-type` is not already set, it sets the `apns-push-type` header to `background`
  * the `content-available` field is set to `1`

### How to test

* Update your project's dependencies to use this branch
   ```shell
   composer require -W "kreait/firebase-php:dev-700-priority-content-available as 6.4"
   ```
* Send a notification to an iOS device and check if it works
* Send a backend message to an iOS device and check if it works

:octocat: 