### PR TITLE
Let AndroidConfig be more lenient with TTL values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* The `AndroidConfig` class is now more lenient with TTL values
+  ([#713](https://github.com/kreait/firebase-php/issues/713)
+
 ## [6.5.1] - 2022-06-27
 
 ### Fixed

--- a/src/Firebase/Messaging/AndroidConfig.php
+++ b/src/Firebase/Messaging/AndroidConfig.php
@@ -108,8 +108,8 @@ final class AndroidConfig implements JsonSerializable
      */
     public static function fromArray(array $config): self
     {
-        if ($ttl = $config['ttl'] ?? null) {
-            $config['ttl'] = self::ensureValidTtl($ttl);
+        if (array_key_exists('ttl', $config)) {
+            $config['ttl'] = self::ensureValidTtl($config['ttl']);
         }
 
         return new self($config);
@@ -127,7 +127,7 @@ final class AndroidConfig implements JsonSerializable
         $expectedPattern = '/^\d+s$/';
         $errorMessage = "The TTL of an AndroidConfig must be an positive integer or string matching $expectedPattern";
 
-        if (is_int($value) && $value > 0) {
+        if (is_int($value) && $value >= 0) {
             return sprintf('%ds', $value);
         }
 

--- a/src/Firebase/Messaging/AndroidConfig.php
+++ b/src/Firebase/Messaging/AndroidConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Messaging;
 
 use JsonSerializable;
+use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 
 /**
  * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidconfig
@@ -60,7 +61,7 @@ use JsonSerializable;
  * @phpstan-type AndroidConfigShape array{
  *     collapse_key?: non-empty-string,
  *     priority?: self::MESSAGE_PRIORITY_*,
- *     ttl?: positive-int,
+ *     ttl?: positive-int|non-empty-string,
  *     restricted_package_name?: non-empty-string,
  *     data?: array<non-empty-string, non-empty-string>,
  *     notification?: AndroidNotificationShape,
@@ -102,10 +103,47 @@ final class AndroidConfig implements JsonSerializable
 
     /**
      * @param AndroidConfigShape $config
+     *
+     * @throws InvalidArgument
      */
     public static function fromArray(array $config): self
     {
+        if ($ttl = $config['ttl'] ?? null) {
+            $config['ttl'] = self::ensureValidTtl($ttl);
+        }
+
         return new self($config);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @throws InvalidArgument
+     *
+     * @return non-empty-string
+     */
+    private static function ensureValidTtl($value): string
+    {
+        $expectedPattern = '/^\d+s$/';
+        $errorMessage = "The TTL of an AndroidConfig must be an positive integer or string matching $expectedPattern";
+
+        if (is_int($value) && $value > 0) {
+            return sprintf('%ds', $value);
+        }
+
+        if (!is_string($value)) {
+            throw new InvalidArgument($errorMessage);
+        }
+
+        if (preg_match('/^\d+$/', $value) === 1) {
+            return sprintf('%ds', $value);
+        }
+
+        if (preg_match($expectedPattern, $value) === 1) {
+            return sprintf('%s', $value);
+        }
+
+        throw new InvalidArgument($errorMessage);
     }
 
     public function withDefaultSound(): self

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -9,7 +9,9 @@ use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\NotFound;
 use Kreait\Firebase\Exception\MessagingException;
+use Kreait\Firebase\Messaging\AndroidConfig;
 use Kreait\Firebase\Messaging\CloudMessage;
+use Kreait\Firebase\Messaging\MessageTarget;
 use Kreait\Firebase\Messaging\RawMessageFromArray;
 use Kreait\Firebase\Tests\IntegrationTestCase;
 
@@ -357,5 +359,55 @@ final class MessagingTest extends IntegrationTestCase
     {
         $this->expectException(NotFound::class);
         $this->messaging->getAppInstance(self::$unknownToken);
+    }
+
+    /**
+     * @see https://github.com/kreait/firebase-php/issues/713
+     */
+    public function testAndroidConfigTtlWorksWithAPositiveInt(): void
+    {
+        $config = AndroidConfig::fromArray([
+            'ttl' => 1,
+        ]);
+
+        $message = CloudMessage::withTarget(MessageTarget::TOKEN, $this->getTestRegistrationToken())
+            ->withAndroidConfig($config);
+
+        $this->messaging->send($message);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @see https://github.com/kreait/firebase-php/issues/713
+     *
+     * @dataProvider validAndroidConfigTtlValues
+     *
+     * @param int|string $value
+     */
+    public function testAndroidConfigTtlWorksWithValidValues($value): void
+    {
+        $config = AndroidConfig::fromArray([
+            'ttl' => $value,
+        ]);
+
+        $message = CloudMessage::withTarget(MessageTarget::TOKEN, $this->getTestRegistrationToken())
+            ->withAndroidConfig($config);
+
+        $this->messaging->send($message);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return array<string, list<mixed>>
+     */
+    public function validAndroidConfigTtlValues(): array
+    {
+        return [
+            'int' => [1],
+            'numeric string' => ['1'],
+            'valid string' => ['1s']
+        ];
     }
 }

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -381,7 +381,7 @@ final class MessagingTest extends IntegrationTestCase
     /**
      * @see https://github.com/kreait/firebase-php/issues/713
      *
-     * @dataProvider validAndroidConfigTtlValues
+     * @dataProvider \Kreait\Firebase\Tests\Unit\Messaging\AndroidConfigTest::validTtlValues
      *
      * @param int|string $value
      */
@@ -397,20 +397,5 @@ final class MessagingTest extends IntegrationTestCase
         $this->messaging->send($message);
 
         $this->addToAssertionCount(1);
-    }
-
-    /**
-     * @return array<string, list<mixed>>
-     */
-    public function validAndroidConfigTtlValues(): array
-    {
-        return [
-            'int' => [1],
-            'numeric string' => ['1'],
-            'valid string' => ['1s'],
-            'zero' => [0],
-            'zero string' => ['0'],
-            'zero s string' => ['0s'],
-        ];
     }
 }

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -407,7 +407,10 @@ final class MessagingTest extends IntegrationTestCase
         return [
             'int' => [1],
             'numeric string' => ['1'],
-            'valid string' => ['1s']
+            'valid string' => ['1s'],
+            'zero' => [0],
+            'zero string' => ['0'],
+            'zero s string' => ['0s'],
         ];
     }
 }

--- a/tests/Unit/Messaging/AndroidConfigTest.php
+++ b/tests/Unit/Messaging/AndroidConfigTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\Tests\Unit\Messaging;
 
+use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 use Kreait\Firebase\Messaging\AndroidConfig;
 use Kreait\Firebase\Tests\UnitTestCase;
 
@@ -49,7 +50,35 @@ final class AndroidConfigTest extends UnitTestCase
     {
         $config = AndroidConfig::fromArray($data);
 
-        $this->assertEquals($data, $config->jsonSerialize());
+        $this->assertEqualsCanonicalizing($data, $config->jsonSerialize());
+    }
+
+    /**
+     * @dataProvider validTtlValues
+     *
+     * @param int|string $ttl
+     */
+    public function testItAcceptsValidTtls($ttl): void
+    {
+        AndroidConfig::fromArray([
+            'ttl' => $ttl,
+        ]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider invalidTtlValues
+     *
+     * @param mixed $ttl
+     */
+    public function testItRejectsInvalidTtls($ttl): void
+    {
+        $this->expectException(InvalidArgument::class);
+
+        AndroidConfig::fromArray([
+            'ttl' => $ttl,
+        ]);
     }
 
     /**
@@ -70,6 +99,33 @@ final class AndroidConfigTest extends UnitTestCase
                     'sound' => 'default',
                 ],
             ]],
+        ];
+    }
+
+    /**
+     * @return array<string, list<int|string>>
+     */
+    public function validTtlValues(): array
+    {
+        return [
+            'positive int' => [1],
+            'positive numeric string' => ['1'],
+            'expected string' => ['1s'],
+        ];
+    }
+
+
+    /**
+     * @return array<string, list<mixed>>
+     */
+    public function invalidTtlValues(): array
+    {
+        return [
+            'float' => [1.2],
+            'wrong suffix' => ['1m'],
+            'not numeric' => [true],
+            'negative int' => [-1],
+            'negative string' => ['-1s']
         ];
     }
 }

--- a/tests/Unit/Messaging/AndroidConfigTest.php
+++ b/tests/Unit/Messaging/AndroidConfigTest.php
@@ -111,6 +111,9 @@ final class AndroidConfigTest extends UnitTestCase
             'positive int' => [1],
             'positive numeric string' => ['1'],
             'expected string' => ['1s'],
+            'zero' => [0],
+            'zero string' => ['0'],
+            'zero string with suffix' => ['0s'],
         ];
     }
 
@@ -125,7 +128,8 @@ final class AndroidConfigTest extends UnitTestCase
             'wrong suffix' => ['1m'],
             'not numeric' => [true],
             'negative int' => [-1],
-            'negative string' => ['-1s']
+            'negative string' => ['-1'],
+            'negative string with suffix' => ['-1s'],
         ];
     }
 }


### PR DESCRIPTION
Fixes #713

* Fixed array shape for `AndroidConfig` objects
* Allow numeric and string values
  * Positive `int`s ore numeric strings matching `int` values are converted to strings ending with `s` (`1` => `'1s'`)
  * Strings matching `/^\d+s$/` are passed through
  * All other values throw an `InvalidArgument` exception to prevent a message from being sent, just to return an error

:octocat: