### PR TITLE
Let WebPushConfig be more lenient with TTL values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* The `WebPushConfig` class is now more lenient with TTL values, and urgencies are checked if they are valid
+  ([#713](https://github.com/kreait/firebase-php/issues/716)
+
 ## [6.6.0] - 2022-07-07
 
 ### Fixed

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -363,23 +363,6 @@ final class MessagingTest extends IntegrationTestCase
 
     /**
      * @see https://github.com/kreait/firebase-php/issues/713
-     */
-    public function testAndroidConfigTtlWorksWithAPositiveInt(): void
-    {
-        $config = AndroidConfig::fromArray([
-            'ttl' => 1,
-        ]);
-
-        $message = CloudMessage::withTarget(MessageTarget::TOKEN, $this->getTestRegistrationToken())
-            ->withAndroidConfig($config);
-
-        $this->messaging->send($message);
-
-        $this->addToAssertionCount(1);
-    }
-
-    /**
-     * @see https://github.com/kreait/firebase-php/issues/713
      *
      * @dataProvider \Kreait\Firebase\Tests\Unit\Messaging\AndroidConfigTest::validTtlValues
      *

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -13,10 +13,13 @@ use Kreait\Firebase\Messaging\AndroidConfig;
 use Kreait\Firebase\Messaging\CloudMessage;
 use Kreait\Firebase\Messaging\MessageTarget;
 use Kreait\Firebase\Messaging\RawMessageFromArray;
+use Kreait\Firebase\Messaging\WebPushConfig;
 use Kreait\Firebase\Tests\IntegrationTestCase;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type WebPushHeadersShape from WebPushConfig
  */
 final class MessagingTest extends IntegrationTestCase
 {
@@ -376,6 +379,27 @@ final class MessagingTest extends IntegrationTestCase
 
         $message = CloudMessage::withTarget(MessageTarget::TOKEN, $this->getTestRegistrationToken())
             ->withAndroidConfig($config);
+
+        $this->messaging->send($message);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @see https://github.com/kreait/firebase-php/issues/716
+     *
+     * @dataProvider \Kreait\Firebase\Tests\Unit\Messaging\WebPushConfigTest::validHeaders
+     *
+     * @param WebPushHeadersShape $headers
+     */
+    public function testWebPushConfigTtlWorksWithValidValues(array $headers): void
+    {
+        $config = WebPushConfig::fromArray([
+            'headers' => $headers,
+        ]);
+
+        $message = CloudMessage::withTarget(MessageTarget::TOKEN, $this->getTestRegistrationToken())
+            ->withWebPushConfig($config);
 
         $this->messaging->send($message);
 

--- a/tests/Unit/Messaging/AndroidConfigTest.php
+++ b/tests/Unit/Messaging/AndroidConfigTest.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\Tests\Unit\Messaging;
 
+use Beste\Json;
 use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 use Kreait\Firebase\Messaging\AndroidConfig;
 use Kreait\Firebase\Tests\UnitTestCase;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type AndroidConfigShape from AndroidConfig
  */
 final class AndroidConfigTest extends UnitTestCase
 {
     public function testItIsEmptyWhenItIsEmpty(): void
     {
-        $this->assertSame('[]', \json_encode(AndroidConfig::new()));
+        $this->assertSame('[]', Json::encode(AndroidConfig::new()));
     }
 
     public function testItHasADefaultSound(): void
@@ -27,24 +30,24 @@ final class AndroidConfigTest extends UnitTestCase
         ];
 
         $this->assertJsonStringEqualsJsonString(
-            \json_encode($expected),
-            \json_encode(AndroidConfig::new()->withDefaultSound())
+            Json::encode($expected),
+            Json::encode(AndroidConfig::new()->withDefaultSound())
         );
     }
 
     public function testItCanHaveAPriority(): void
     {
-        $config = AndroidConfig::new()->withNormalPriority();
+        $config = AndroidConfig::new()->withNormalMessagePriority();
         $this->assertSame('normal', $config->jsonSerialize()['priority']);
 
-        $config = AndroidConfig::new()->withHighPriority();
+        $config = AndroidConfig::new()->withHighMessagePriority();
         $this->assertSame('high', $config->jsonSerialize()['priority']);
     }
 
     /**
      * @dataProvider validDataProvider
      *
-     * @param array<string, array<string, mixed>> $data
+     * @param AndroidConfigShape $data
      */
     public function testItCanBeCreatedFromAnArray(array $data): void
     {
@@ -82,7 +85,7 @@ final class AndroidConfigTest extends UnitTestCase
     }
 
     /**
-     * @return array<string, array<int, array<string, mixed>>>
+     * @return array<array-key, list<AndroidConfigShape>>
      */
     public function validDataProvider(): array
     {

--- a/tests/Unit/Messaging/WebPushConfigTest.php
+++ b/tests/Unit/Messaging/WebPushConfigTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\Tests\Unit\Messaging;
 
+use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 use Kreait\Firebase\Messaging\WebPushConfig;
 use Kreait\Firebase\Tests\UnitTestCase;
 
 /**
  * @internal
+ * @phpstan-import-type WebPushConfigShape from WebPushConfig
+ * @phpstan-import-type WebPushHeadersShape from WebPushConfig
  */
 final class WebPushConfigTest extends UnitTestCase
 {
@@ -17,7 +20,7 @@ final class WebPushConfigTest extends UnitTestCase
      *
      * @param array<string, mixed> $data
      */
-    public function testCreateFromArray(array $data): void
+    public function testCreateFromValidPayload(array $data): void
     {
         $config = WebPushConfig::fromArray($data);
 
@@ -40,7 +43,19 @@ final class WebPushConfigTest extends UnitTestCase
     }
 
     /**
-     * @return array<string, array<string, array<string, mixed>>>
+     * @dataProvider invalidHeaders
+     *
+     * @param WebPushHeadersShape $headers
+     */
+    public function testItRejectsInvalidHeaders(array $headers): void
+    {
+        $this->expectException(InvalidArgument::class);
+
+        WebPushConfig::fromArray(['headers' => $headers]);
+    }
+
+    /**
+     * @return array<string, array<WebPushConfigShape>>
      */
     public function validDataProvider(): array
     {
@@ -56,6 +71,31 @@ final class WebPushConfigTest extends UnitTestCase
                     'icon' => 'https://my-server/icon.png',
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<WebPushHeadersShape>>
+     */
+    public function validHeaders(): array
+    {
+        return [
+            'positive int ttl' => [['TTL' => 1]],
+            'positive string ttl' => [['TTL' => '1']],
+        ];
+    }
+
+    /**
+     * @return array<string, array<array<string, mixed>>>
+     */
+    public function invalidHeaders(): array
+    {
+        return [
+            'negative int ttl' => [['TTL' => -1]],
+            'negative string ttl' => [['TTL' => '-1']],
+            'zero int ttl' => [['TTL' => -1]],
+            'zero string ttl' => [['TTL' => '-1']],
+            'unsupported urgency' => [['Urgency' => 'unsupported']],
         ];
     }
 }


### PR DESCRIPTION
Fixes #716


* Fixes array shape for `WebPushConfig` objects
* Allow numeric and string values
* Positive ints are numeric strings matching positive int values
* All other values throw an InvalidArgument exception to prevent a message from being sent, just to return an error
* Adds check for invalid Urgencies

:octocat: 