### PR TITLE
Add support for the Realtime Database Emulator

### DIFF
--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -67,8 +67,9 @@ jobs:
           TEST_REGISTRATION_TOKENS: ${{secrets.TEST_REGISTRATION_TOKENS}}
           TEST_FIREBASE_RTDB_URI: ${{secrets.TEST_FIREBASE_RTDB_URI}}
           FIREBASE_AUTH_EMULATOR_HOST: localhost:9099
+          FIREBASE_DATABASE_EMULATOR_HOST: localhost:9100
           XDEBUG_MODE: coverage
-        run: firebase emulators:exec --only auth --project beste-firebase 'XDEBUG_MODE=coverage vendor/bin/phpunit --group=emulator --coverage-clover=coverage.xml --log-junit=test-report.xml'
+        run: firebase emulators:exec --only database,auth --project beste-firebase 'XDEBUG_MODE=coverage vendor/bin/phpunit --group=emulator --coverage-clover=coverage.xml --log-junit=test-report.xml'
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+* Added support for the Firebase Auth Emulator.
+  ([#722](https://github.com/kreait/firebase-php/pull/722)) ([Documentation](https://firebase-php.readthedocs.io/en/latest/testing.html))
+
 ### Changed
 
 * The default HTTP Client options have been updated

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -22,17 +22,21 @@ Using the Firebase Emulator Suite
 For an introduction to the Firebase Emulator suite, please visit the official documentation:
 `https://firebase.google.com/docs/emulator-suite <https://firebase.google.com/docs/emulator-suite>`_
 
+.. warning::
+    Only the Auth and Realtime Database Emulators are currently supported in this PHP SDK.
+
 To use the Firebase Emulator Suite, you must first `install it <https://firebase.google.com/docs/cli>`_.
 
-.. warning::
-    Only the Auth Emulator is currently supported. The other Emulators are not yet available,
-    and side-effects could occur.
+See the `official documentation <https://firebase.google.com/docs/emulator-suite/install_and_configure#startup>`_
+for instructions how to work with it.
+
+The emulator suite must be running otherwise the PHP SDK can't connect to it.
 
 Auth Emulator
 -------------
 
-In your project, create a `firebase.json` file and make sure that at least the following fields are set
-(the port number can be changed to your requirements):
+If not already present, create a `firebase.json` file in the root of your project and make sure that at least the
+following fields are set (the port number can be changed to your requirements):
 
 .. code-block:: js
 
@@ -44,7 +48,7 @@ In your project, create a `firebase.json` file and make sure that at least the f
       }
     }
 
-The Firebase Admin SDK automatically connects to the Authentication emulator when the
+Firebase Admin SDKs automatically connect to the Authentication emulator when the
 ``FIREBASE_AUTH_EMULATOR_HOST`` environment variable is set.
 
 .. code-block:: bash
@@ -58,3 +62,30 @@ development and testing. Please make sure not to set the environment variable in
 When connecting to the Authentication emulator, you will need to specify a project ID. You can pass a project ID to
 the Factory directly or set the ``GOOGLE_CLOUD_PROJECT`` environment variable. Note that you do not need to use your
 real Firebase project ID; the Authentication emulator will accept any project ID.
+
+Realtime Database Emulator
+--------------------------
+
+If not already present, create a `firebase.json` file in the root of your project and make sure that at least the
+following fields are set (the port number can be changed to your requirements):
+
+.. code-block:: js
+
+    {
+      "emulators": {
+        "database": {
+          "port": 9100
+        }
+      }
+    }
+
+.. note::
+    The Realtime Database Emulator uses port ``9000`` by default. This port is also used by PHP-FPM, so it is
+    recommended to chose one that differs to not run into conflicts.
+
+Firebase Admin SDKs automatically connect to the Realtime Database emulator when the
+``FIREBASE_DATABASE_EMULATOR_HOST`` environment variable is set.
+
+.. code-block:: bash
+
+    $ export FIREBASE_DATABASE_EMULATOR_HOST="localhost:9100"

--- a/firebase.json
+++ b/firebase.json
@@ -1,10 +1,17 @@
 {
-  "emulators": {
-    "auth": {
-      "port": 9099
+    "database": {
+        "rules": "tests/_fixtures/emulator/database.rules.json"
     },
-    "ui": {
-      "enabled": true
+    "emulators": {
+        "auth": {
+            "port": 9099
+        },
+        "database": {
+            "port": 9100
+        },
+        "ui": {
+            "enabled": true,
+            "port": 4000
+        }
     }
-  }
 }

--- a/src/Firebase/Auth/UserRecord.php
+++ b/src/Firebase/Auth/UserRecord.php
@@ -10,7 +10,7 @@ use Kreait\Firebase\Util\DT;
 
 class UserRecord implements \JsonSerializable
 {
-    public string $uid;
+    public string $uid = '';
     public bool $emailVerified = false;
     public bool $disabled = false;
     public UserMetaData $metadata;
@@ -30,7 +30,6 @@ class UserRecord implements \JsonSerializable
     public function __construct()
     {
         $this->metadata = new UserMetaData();
-        $this->uid = '';
     }
 
     /**

--- a/src/Firebase/Database.php
+++ b/src/Firebase/Database.php
@@ -9,6 +9,7 @@ use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Database\Reference;
 use Kreait\Firebase\Database\RuleSet;
 use Kreait\Firebase\Database\Transaction;
+use Kreait\Firebase\Database\UrlBuilder;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 
@@ -18,13 +19,15 @@ use Psr\Http\Message\UriInterface;
 final class Database implements Contract\Database
 {
     private ApiClient $client;
+    private UrlBuilder $urlBuilder;
 
     private UriInterface $uri;
 
-    public function __construct(UriInterface $uri, ApiClient $client)
+    public function __construct(UriInterface $uri, ApiClient $client, UrlBuilder $urlBuilder)
     {
         $this->uri = $uri;
         $this->client = $client;
+        $this->urlBuilder = $urlBuilder;
     }
 
     public function getReference(?string $path = null): Reference
@@ -36,7 +39,7 @@ final class Database implements Contract\Database
         $path = '/'.\ltrim($path, '/');
 
         try {
-            return new Reference($this->uri->withPath($path), $this->client);
+            return new Reference($this->uri->withPath($path), $this->client, $this->urlBuilder);
         } catch (\InvalidArgumentException $e) {
             throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }
@@ -59,14 +62,14 @@ final class Database implements Contract\Database
 
     public function getRuleSet(): RuleSet
     {
-        $rules = $this->client->get($this->uri->withPath('/.settings/rules'));
+        $rules = $this->client->get('/.settings/rules');
 
         return RuleSet::fromArray($rules);
     }
 
     public function updateRules(RuleSet $ruleSet): void
     {
-        $this->client->updateRules($this->uri->withPath('/.settings/rules'), $ruleSet);
+        $this->client->updateRules('/.settings/rules', $ruleSet);
     }
 
     public function runTransaction(callable $callable)

--- a/src/Firebase/Database/ApiClient.php
+++ b/src/Firebase/Database/ApiClient.php
@@ -10,7 +10,6 @@ use GuzzleHttp\Psr7\Request;
 use Kreait\Firebase\Exception\DatabaseApiExceptionConverter;
 use Kreait\Firebase\Exception\DatabaseException;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\UriInterface;
 use Throwable;
 
 /**
@@ -20,37 +19,35 @@ class ApiClient
 {
     private ClientInterface $client;
     protected DatabaseApiExceptionConverter $errorHandler;
+    private UrlBuilder $resourceUrlBuilder;
 
-    public function __construct(ClientInterface $httpClient)
+    public function __construct(ClientInterface $httpClient, UrlBuilder $resourceUrlBuilder)
     {
         $this->client = $httpClient;
         $this->errorHandler = new DatabaseApiExceptionConverter();
+        $this->resourceUrlBuilder = $resourceUrlBuilder;
     }
 
     /**
-     * @param UriInterface|string $uri
-     *
      * @throws DatabaseException
      *
      * @return mixed
      */
-    public function get($uri)
+    public function get(string $path)
     {
-        $response = $this->requestApi('GET', $uri);
+        $response = $this->requestApi('GET', $path);
 
         return Json::decode((string) $response->getBody(), true);
     }
 
     /**
-     * @param UriInterface|string $uri
-     *
      * @throws DatabaseException
      *
      * @return array<string, mixed>
      */
-    public function getWithETag($uri): array
+    public function getWithETag(string $path): array
     {
-        $response = $this->requestApi('GET', $uri, [
+        $response = $this->requestApi('GET', $path, [
             'headers' => [
                 'X-Firebase-ETag' => 'true',
             ],
@@ -66,31 +63,28 @@ class ApiClient
     }
 
     /**
-     * @param UriInterface|string $uri
      * @param mixed $value
      *
      * @throws DatabaseException
      *
      * @return mixed
      */
-    public function set($uri, $value)
+    public function set(string $path, $value)
     {
-        $response = $this->requestApi('PUT', $uri, ['json' => $value]);
+        $response = $this->requestApi('PUT', $path, ['json' => $value]);
 
         return Json::decode((string) $response->getBody(), true);
     }
 
     /**
-     * @param UriInterface|string $uri
      * @param mixed $value
      *
      * @throws DatabaseException
-     *
      * @return mixed
      */
-    public function setWithEtag($uri, $value, string $etag)
+    public function setWithEtag(string $path, $value, string $etag)
     {
-        $response = $this->requestApi('PUT', $uri, [
+        $response = $this->requestApi('PUT', $path, [
             'headers' => [
                 'if-match' => $etag,
             ],
@@ -101,13 +95,11 @@ class ApiClient
     }
 
     /**
-     * @param UriInterface|string $uri
-     *
      * @throws DatabaseException
      */
-    public function removeWithEtag($uri, string $etag): void
+    public function removeWithEtag(string $path, string $etag): void
     {
-        $this->requestApi('DELETE', $uri, [
+        $this->requestApi('DELETE', $path, [
             'headers' => [
                 'if-match' => $etag,
             ],
@@ -115,18 +107,16 @@ class ApiClient
     }
 
     /**
-     * @param UriInterface|string $uri
-     *
      * @throws DatabaseException
      *
      * @return mixed
      */
-    public function updateRules($uri, RuleSet $ruleSet)
+    public function updateRules(string $path, RuleSet $ruleSet)
     {
         $rules = $ruleSet->getRules();
         $encodedRules = Json::encode((object) $rules);
 
-        $response = $this->requestApi('PUT', $uri, [
+        $response = $this->requestApi('PUT', $path, [
             'body' => $encodedRules,
         ]);
 
@@ -134,50 +124,47 @@ class ApiClient
     }
 
     /**
-     * @param UriInterface|string $uri
      * @param mixed $value
      *
      * @throws DatabaseException
      */
-    public function push($uri, $value): string
+    public function push(string $path, $value): string
     {
-        $response = $this->requestApi('POST', $uri, ['json' => $value]);
+        $response = $this->requestApi('POST', $path, ['json' => $value]);
 
         return Json::decode((string) $response->getBody(), true)['name'];
     }
 
     /**
-     * @param UriInterface|string $uri
-     *
      * @throws DatabaseException
      */
-    public function remove($uri): void
+    public function remove(string $path): void
     {
-        $this->requestApi('DELETE', $uri);
+        $this->requestApi('DELETE', $path);
     }
 
     /**
-     * @param UriInterface|string $uri
-     * @param array<mixed> $values
+     * @param array<array-key, mixed> $values
      *
      * @throws DatabaseException
      */
-    public function update($uri, array $values): void
+    public function update(string $path, array $values): void
     {
-        $this->requestApi('PATCH', $uri, ['json' => $values]);
+        $this->requestApi('PATCH', $path, ['json' => $values]);
     }
 
     /**
-     * @param UriInterface|string $uri
      * @param array<string, mixed>|null $options
      *
      * @throws DatabaseException
      */
-    private function requestApi(string $method, $uri, ?array $options = null): ResponseInterface
+    private function requestApi(string $method, string $path, ?array $options = []): ResponseInterface
     {
         $options ??= [];
 
-        $request = new Request($method, $uri);
+        $url = $this->resourceUrlBuilder->getUrl($path);
+
+        $request = new Request($method, $url);
 
         try {
             return $this->client->send($request, $options);

--- a/src/Firebase/Database/Query.php
+++ b/src/Firebase/Database/Query.php
@@ -29,7 +29,7 @@ class Query
     private Reference $reference;
     private ApiClient $apiClient;
     /** @var Filter[] */
-    private array $filters;
+    private array $filters = [];
     private ?Sorter $sorter = null;
 
     /**
@@ -39,7 +39,6 @@ class Query
     {
         $this->reference = $reference;
         $this->apiClient = $apiClient;
-        $this->filters = [];
     }
 
     /**
@@ -60,7 +59,7 @@ class Query
     public function getSnapshot(): Snapshot
     {
         try {
-            $value = $this->apiClient->get($this->getUri());
+            $value = $this->apiClient->get($this->getUri()->getPath());
         } catch (DatabaseNotFound $e) {
             throw $e;
         } catch (DatabaseException $e) {

--- a/src/Firebase/Database/Reference/Validator.php
+++ b/src/Firebase/Database/Reference/Validator.php
@@ -16,11 +16,21 @@ class Validator
     /**
      * Checks the reference URI for invalid properties.
      *
-     * @throws InvalidArgumentException on
+     * @throws InvalidArgumentException
      */
     public function validateUri(UriInterface $uri): void
     {
-        $path = \trim($uri->getPath(), '/');
+        $this->validatePath($uri->getPath());
+    }
+
+    /**
+     * Checks a reference path for invalid properties.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function validatePath(string $path): void
+    {
+        $path = trim($path, '/');
 
         $this->validateDepth($path);
 

--- a/src/Firebase/Database/Transaction.php
+++ b/src/Firebase/Database/Transaction.php
@@ -29,11 +29,11 @@ class Transaction
      */
     public function snapshot(Reference $reference): Snapshot
     {
-        $uri = (string) $reference->getUri();
+        $path = $reference->getPath();
 
-        $result = $this->apiClient->getWithETag($uri);
+        $result = $this->apiClient->getWithETag($path);
 
-        $this->etags[$uri] = $result['etag'];
+        $this->etags[$path] = $result['etag'];
 
         return new Snapshot($reference, $result['value']);
     }
@@ -49,7 +49,7 @@ class Transaction
         $etag = $this->getEtagForReference($reference);
 
         try {
-            $this->apiClient->setWithEtag($reference->getUri(), $value, $etag);
+            $this->apiClient->setWithEtag($reference->getPath(), $value, $etag);
         } catch (DatabaseException $e) {
             throw TransactionFailed::onReference($reference, $e);
         }
@@ -64,7 +64,7 @@ class Transaction
         $etag = $this->getEtagForReference($reference);
 
         try {
-            $this->apiClient->removeWithEtag($reference->getUri(), $etag);
+            $this->apiClient->removeWithEtag($reference->getPath(), $etag);
         } catch (DatabaseException $e) {
             throw TransactionFailed::onReference($reference, $e);
         }
@@ -75,10 +75,10 @@ class Transaction
      */
     private function getEtagForReference(Reference $reference): string
     {
-        $uri = (string) $reference->getUri();
+        $path = $reference->getPath();
 
-        if (\array_key_exists($uri, $this->etags)) {
-            return $this->etags[$uri];
+        if (\array_key_exists($path, $this->etags)) {
+            return $this->etags[$path];
         }
 
         throw new ReferenceHasNotBeenSnapshotted($reference);

--- a/src/Firebase/Database/UrlBuilder.php
+++ b/src/Firebase/Database/UrlBuilder.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Database;
+
+use Kreait\Firebase\Exception\InvalidArgumentException;
+use Kreait\Firebase\Util;
+
+final class UrlBuilder
+{
+    private const EXPECTED_URL_FORMAT = '@^https://(?P<namespace>[^.]+)\.(?P<host>.+)$@';
+
+    /** @phpstan-var 'http'|'https' */
+    private string $scheme;
+
+    /** @var non-empty-string */
+    private string $host;
+
+    /** @var array<string, string> */
+    private array $defaultQueryParams;
+
+    /**
+     * @phpstan-param 'http'|'https' $scheme
+     * @param non-empty-string $host
+     * @param array<string, string> $defaultQueryParams
+     */
+    private function __construct(string $scheme, string $host, array $defaultQueryParams)
+    {
+        $this->scheme = $scheme;
+        $this->host = $host;
+        $this->defaultQueryParams = $defaultQueryParams;
+    }
+
+    /**
+     * @param non-empty-string $databaseUrl
+     */
+    public static function create(string $databaseUrl): self
+    {
+        ['scheme' => $scheme, 'host' => $host, 'query' => $query] = self::parseDatabaseUrl($databaseUrl);
+
+        return new self($scheme, $host, $query);
+    }
+
+    /**
+     * @param non-empty-string $databaseUrl
+     *
+     * @return array{
+     *     scheme: 'http'|'https',
+     *     host: non-empty-string,
+     *     query: array<non-empty-string, non-empty-string>
+     * }
+     */
+    private static function parseDatabaseUrl(string $databaseUrl): array
+    {
+        $databaseUrl = rtrim($databaseUrl, '/');
+
+        if (preg_match(self::EXPECTED_URL_FORMAT, $databaseUrl, $matches) !== 1) {
+            throw new InvalidArgumentException('Unexpected database URL format "'.$databaseUrl.'"');
+        }
+
+        $namespace = $matches['namespace'];
+        assert(is_string($namespace) && $namespace !== '');
+        $host = $matches['host'];
+        assert(is_string($host) && $host !== '');
+
+        if (($emulatorHost = Util::rtdbEmulatorHost()) !== '' && ($emulatorHost = Util::rtdbEmulatorHost()) !== '0') {
+            return [
+                'scheme' => 'http',
+                'host' => $emulatorHost,
+                'query' => ['ns' => $namespace],
+            ];
+        }
+
+        return [
+            'scheme' => 'https',
+            'host' => $namespace.'.'.$host,
+            'query' => [],
+        ];
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    public function getUrl(string $path, array $queryParams = []): string
+    {
+        $allQueryParams = $this->defaultQueryParams + $queryParams;
+        $path = '/'.trim($path, '/');
+
+        $url = strtr('{scheme}://{host}{path}?{queryParams}', [
+            '{scheme}' => $this->scheme,
+            '{host}' => $this->host,
+            '{path}' => $path,
+            '{queryParams}' => http_build_query($allQueryParams)
+        ]);
+
+        // If no queryParams are present, remove the trailing '?'
+        return trim($url, '?');
+    }
+}

--- a/src/Firebase/Http/RequestWithSubRequests.php
+++ b/src/Firebase/Http/RequestWithSubRequests.php
@@ -57,12 +57,9 @@ final class RequestWithSubRequests implements HasSubRequests, RequestInterface
         $this->appendStream("--{$this->boundary}--");
 
         $request = new Request($this->method, $uri, $headers, $this->body, $version);
-
-        if (($requestBody = $request->getBody()) !== null) {
-            $contentLength = $requestBody->getSize();
-            if ($contentLength !== null) {
-                $request = $request->withHeader('Content-Length', (string) $contentLength);
-            }
+        $contentLength = $request->getBody()->getSize();
+        if ($contentLength !== null) {
+            $request = $request->withHeader('Content-Length', (string) $contentLength);
         }
 
         $this->wrappedRequest = $request;

--- a/src/Firebase/Messaging.php
+++ b/src/Firebase/Messaging.php
@@ -208,9 +208,8 @@ final class Messaging implements Contract\Messaging
         $message = $message instanceof Message ? $message : CloudMessage::fromArray($message);
 
         $message = (new SetApnsPushTypeIfNeeded())($message);
-        $message = (new SetApnsContentAvailableIfNeeded())($message);
 
-        return $message;
+        return (new SetApnsContentAvailableIfNeeded())($message);
     }
 
     private function messageHasTarget(Message $message): bool

--- a/src/Firebase/Messaging/AndroidConfig.php
+++ b/src/Firebase/Messaging/AndroidConfig.php
@@ -116,7 +116,7 @@ final class AndroidConfig implements JsonSerializable
     }
 
     /**
-     * @param mixed $value
+     * @param int|string $value
      *
      * @throws InvalidArgument
      *
@@ -131,7 +131,7 @@ final class AndroidConfig implements JsonSerializable
             return sprintf('%ds', $value);
         }
 
-        if (!is_string($value)) {
+        if (!is_string($value) || $value === '') {
             throw new InvalidArgument($errorMessage);
         }
 
@@ -140,7 +140,7 @@ final class AndroidConfig implements JsonSerializable
         }
 
         if (preg_match($expectedPattern, $value) === 1) {
-            return sprintf('%s', $value);
+            return $value;
         }
 
         throw new InvalidArgument($errorMessage);

--- a/src/Firebase/Messaging/WebPushConfig.php
+++ b/src/Firebase/Messaging/WebPushConfig.php
@@ -121,13 +121,11 @@ final class WebPushConfig implements JsonSerializable
             }
         }
 
-        if (array_key_exists('Urgency', $headers)) {
-            if (!in_array($headers['Urgency'], self::VALID_URGENCIES, true)) {
-                throw new InvalidArgument(sprintf(
-                    'The Urgency in the WebPushConfig header must must be one of %s',
-                    implode(',', self::VALID_URGENCIES)
-                ));
-            }
+        if (array_key_exists('Urgency', $headers) && !in_array($headers['Urgency'], self::VALID_URGENCIES, true)) {
+            throw new InvalidArgument(sprintf(
+                'The Urgency in the WebPushConfig header must must be one of %s',
+                implode(',', self::VALID_URGENCIES)
+            ));
         }
 
         return $headers;

--- a/src/Firebase/Util.php
+++ b/src/Firebase/Util.php
@@ -45,4 +45,15 @@ final class Util
 
         return '';
     }
+
+    public static function rtdbEmulatorHost(): string
+    {
+        $emulatorHost = self::getenv('FIREBASE_DATABASE_EMULATOR_HOST');
+
+        if (!\in_array($emulatorHost, [null, ''], true)) {
+            return $emulatorHost;
+        }
+
+        return '';
+    }
 }

--- a/tests/Integration/Auth/CustomTokenViaGoogleIamTest.php
+++ b/tests/Integration/Auth/CustomTokenViaGoogleIamTest.php
@@ -13,6 +13,8 @@ use Throwable;
 
 /**
  * @internal
+ * @group auth-emulator
+ * @group emulator
  */
 final class CustomTokenViaGoogleIamTest extends IntegrationTestCase
 {

--- a/tests/Integration/AuthTest.php
+++ b/tests/Integration/AuthTest.php
@@ -6,6 +6,7 @@ namespace Kreait\Firebase\Tests\Integration;
 
 /**
  * @internal
+ * @group auth-emulator
  * @group emulator
  */
 final class AuthTest extends AuthTestCase

--- a/tests/Integration/AuthTestCase.php
+++ b/tests/Integration/AuthTestCase.php
@@ -192,7 +192,7 @@ abstract class AuthTestCase extends IntegrationTestCase
 
         $link = $this->auth->getEmailVerificationLink($user->email, null, 'fr');
 
-        if (self::isEmulated()) {
+        if (self::authIsEmulated()) {
             $this->assertStringNotContainsString('lang=fr', $link);
         } else {
             $this->assertStringContainsString('lang=fr', $link);

--- a/tests/Integration/Database/AuthVariableOverrideTest.php
+++ b/tests/Integration/Database/AuthVariableOverrideTest.php
@@ -12,6 +12,8 @@ use Kreait\Firebase\Tests\Integration\DatabaseTestCase;
 
 /**
  * @internal
+ * @group database-emulator
+ * @group emulator
  */
 final class AuthVariableOverrideTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/ReferenceTest.php
+++ b/tests/Integration/Database/ReferenceTest.php
@@ -11,6 +11,8 @@ use Kreait\Firebase\Util\DT;
 
 /**
  * @internal
+ * @group database-emulator
+ * @group emulator
  */
 final class ReferenceTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/RuleSetTest.php
+++ b/tests/Integration/Database/RuleSetTest.php
@@ -10,6 +10,8 @@ use Kreait\Firebase\Tests\Integration\DatabaseTestCase;
 
 /**
  * @internal
+ * @group database-emulator
+ * @group emulator
  */
 final class RuleSetTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/TransactionTest.php
+++ b/tests/Integration/Database/TransactionTest.php
@@ -11,6 +11,8 @@ use Kreait\Firebase\Tests\Integration\DatabaseTestCase;
 
 /**
  * @internal
+ * @group database-emulator
+ * @group emulator
  */
 final class TransactionTest extends DatabaseTestCase
 {

--- a/tests/Integration/DatabaseTest.php
+++ b/tests/Integration/DatabaseTest.php
@@ -9,11 +9,17 @@ use Kreait\Firebase\Factory;
 
 /**
  * @internal
+ * @group database-emulator
+ * @group emulator
  */
 final class DatabaseTest extends DatabaseTestCase
 {
     public function testWithNonExistingDatabase(): void
     {
+        if (self::databaseIsEmulated()) {
+            $this->markTestSkipped('The RTDB emulator creates databases if they don\'t exist');
+        }
+
         $credentials = self::$serviceAccount->asArray();
         $credentials['project_id'] = 'non-existing';
 

--- a/tests/Integration/DatabaseTestCase.php
+++ b/tests/Integration/DatabaseTestCase.php
@@ -8,6 +8,9 @@ use GuzzleHttp\Client;
 use Kreait\Firebase\Contract\Database;
 use Kreait\Firebase\Tests\IntegrationTestCase;
 
+/**
+ * @internal
+ */
 abstract class DatabaseTestCase extends IntegrationTestCase
 {
     protected static string $refPrefix;

--- a/tests/Integration/TenantAwareAuthTest.php
+++ b/tests/Integration/TenantAwareAuthTest.php
@@ -7,6 +7,7 @@ namespace Kreait\Firebase\Tests\Integration;
 /**
  * @internal
  *
+ * @group auth-emulator
  * @group emulator
  */
 final class TenantAwareAuthTest extends AuthTestCase

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -63,9 +63,14 @@ abstract class IntegrationTestCase extends FirebaseTestCase
         return self::randomString($suffix.'@domain.tld');
     }
 
-    protected static function isEmulated(): bool
+    protected static function authIsEmulated(): bool
     {
-        return !\in_array(Util::getenv('FIREBASE_AUTH_EMULATOR_HOST'), [null, ''], true);
+        return Util::authEmulatorHost() !== '';
+    }
+
+    protected static function databaseIsEmulated(): bool
+    {
+        return Util::rtdbEmulatorHost() !== '';
     }
 
     private static function credentialsFromFile(): ?ServiceAccount

--- a/tests/Unit/Database/ApiClientTest.php
+++ b/tests/Unit/Database/ApiClientTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Kreait\Firebase\Database\ApiClient;
+use Kreait\Firebase\Database\UrlBuilder;
 use Kreait\Firebase\Exception\DatabaseException;
 use Kreait\Firebase\Tests\UnitTestCase;
 
@@ -26,41 +27,40 @@ final class ApiClientTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        $this->targetUrl = 'https://namespace.db.tld/';
+
         $this->http = $this->createMock(ClientInterface::class);
-        $this->client = new ApiClient($this->http);
-        $this->targetUrl = 'http://domain.tld/some/path';
+        $this->http
+            ->method($this->anything())
+            ->willReturn(new Response(200, [], '{"name":"value"}'))
+        ;
+        $this->client = new ApiClient($this->http, UrlBuilder::create($this->targetUrl));
     }
 
     public function testGet(): void
     {
-        $client = $this->createApiClient();
-
-        $this->assertNotNull($client->get($this->targetUrl));
+        $this->assertNotNull($this->client->get($this->targetUrl));
     }
 
     public function testSet(): void
     {
-        $client = $this->createApiClient();
-
-        $this->assertNotNull($client->set($this->targetUrl, 'any'));
+        $this->assertNotNull($this->client->set($this->targetUrl, 'any'));
     }
 
     public function testPush(): void
     {
-        $client = $this->createApiClient();
-
-        $this->assertNotNull($client->push($this->targetUrl, 'any'));
+        $this->assertNotNull($this->client->push($this->targetUrl, 'any'));
     }
 
     public function testUpdate(): void
     {
-        $this->createApiClient()->update($this->targetUrl, ['any', 'values']);
+        $this->client->update($this->targetUrl, ['any', 'values']);
         $this->addToAssertionCount(1);
     }
 
     public function testRemove(): void
     {
-        $this->createApiClient()->remove($this->targetUrl);
+        $this->client->remove($this->targetUrl);
         $this->addToAssertionCount(1);
     }
 
@@ -88,17 +88,5 @@ final class ApiClientTest extends UnitTestCase
         $this->expectException(DatabaseException::class);
 
         $this->client->get($this->targetUrl);
-    }
-
-    private function createApiClient(): ApiClient
-    {
-        $client = $this->createMock(ClientInterface::class);
-
-        $client
-            ->method($this->anything())
-            ->willReturn(new Response(200, [], '{"name":"value"}'))
-        ;
-
-        return new ApiClient($client);
     }
 }

--- a/tests/Unit/Database/ReferenceTest.php
+++ b/tests/Unit/Database/ReferenceTest.php
@@ -9,6 +9,7 @@ use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Database\Query;
 use Kreait\Firebase\Database\Reference;
 use Kreait\Firebase\Database\Snapshot;
+use Kreait\Firebase\Database\UrlBuilder;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Exception\OutOfRangeException;
 use Kreait\Firebase\Tests\UnitTestCase;
@@ -29,8 +30,13 @@ final class ReferenceTest extends UnitTestCase
         parent::setUp();
 
         $this->apiClient = $this->createMock(ApiClient::class);
+        $url = 'https://project.domain.tld/parent/key';
 
-        $this->reference = new Reference(new Uri('http://domain.tld/parent/key'), $this->apiClient);
+        $this->reference = new Reference(
+            new Uri($url),
+            $this->apiClient,
+            UrlBuilder::create($url)
+        );
     }
 
     public function testGetKey(): void

--- a/tests/Unit/Database/TransactionTest.php
+++ b/tests/Unit/Database/TransactionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\Tests\Unit\Database;
 
-use GuzzleHttp\Psr7\Uri;
 use Kreait\Firebase\Database\ApiClient;
 use Kreait\Firebase\Database\Reference;
 use Kreait\Firebase\Database\Transaction;
@@ -48,29 +47,23 @@ final class TransactionTest extends TestCase
     public function testATransactionCanFail(): void
     {
         $reference = $this->createMock(Reference::class);
-        $reference->method('getUri')->willReturn($uri = new Uri('https://domain.tld'));
+        $reference->method('getPath')->willReturn('/foo');
 
         $this->apiClient
             ->method('getWithETag')
-            ->with($uri)
+            ->with('/foo')
             ->willReturn(['etag' => 'etag', 'value' => 'old value'])
         ;
 
         $this->apiClient
             ->method('setWithEtag')
-            ->with($uri)
+            ->with('/foo')
             ->willThrowException(new DatabaseError())
         ;
 
         $this->transaction->snapshot($reference);
 
-        try {
-            $this->transaction->set($reference, 'new value');
-            $this->fail('An exception should have been thrown');
-        } catch (TransactionFailed $e) {
-            $this->assertSame($reference, $e->getReference());
-        } catch (Throwable $e) {
-            $this->fail('A '.TransactionFailed::class.' should have been thrown');
-        }
+        $this->expectException(TransactionFailed::class);
+        $this->transaction->set($reference, 'new value');
     }
 }

--- a/tests/Unit/Database/UrlBuilderTest.php
+++ b/tests/Unit/Database/UrlBuilderTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\Database;
+
+use InvalidArgumentException;
+use Kreait\Firebase\Database\UrlBuilder;
+use Kreait\Firebase\Tests\UnitTestCase;
+use Kreait\Firebase\Util;
+
+final class UrlBuilderTest extends UnitTestCase
+{
+    protected function tearDown(): void
+    {
+        Util::rmenv('FIREBASE_DATABASE_EMULATOR_HOST');
+    }
+
+    /**
+     * @dataProvider invalidUrls
+     *
+     * @param non-empty-string $url
+     */
+    public function testWithInvalidUrl(string $url): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        UrlBuilder::create($url);
+    }
+
+    /**
+     * @return array<non-empty-string, array<non-empty-string>>
+     */
+    public function invalidUrls(): array
+    {
+        return [
+            'wrong scheme' => ['http://domain.tld'],
+            'no scheme' => ['domain.tld']
+        ];
+    }
+
+    /**
+     * @dataProvider realUrls
+     *
+     * @param non-empty-string $baseUrl
+     * @param array<string, string> $queryParams
+     * @param non-empty-string $expected
+     */
+    public function getGetUrl(string $baseUrl, string $path, array $queryParams, string $expected): void
+    {
+        $url = UrlBuilder::create($baseUrl)->getUrl($path, $queryParams);
+
+        $this->assertSame($expected, $url);
+    }
+
+    /**
+     * @dataProvider emulatedUrls
+     *
+     * @param non-empty-string $emulatorHost
+     * @param non-empty-string $baseUrl
+     * @param array<string, string> $queryParams
+     * @param non-empty-string $expected
+     */
+    public function testEmulated(string $emulatorHost, string $baseUrl, string $path, array $queryParams, string $expected): void
+    {
+        Util::putenv('FIREBASE_DATABASE_EMULATOR_HOST', $emulatorHost);
+        $url = UrlBuilder::create($baseUrl)->getUrl($path, $queryParams);
+
+        $this->assertSame($expected, $url);
+    }
+    /**
+     * @return array<array-key, array<array-key, string|array<string, string>>>
+     */
+    public function realUrls(): array
+    {
+        $baseUrl = 'https://project.region.db.tld';
+
+        return [
+            'empty path, empty query' => [
+                $baseUrl,
+                '',
+                [],
+                $baseUrl.'/',
+            ],
+            'path without trailing slash, empty query' => [
+                $baseUrl,
+                '/path/to/child',
+                [],
+                $baseUrl.'/path/to/child',
+            ],
+            'path with trailing slash, empty query' => [
+                $baseUrl,
+                '/path/to/child/',
+                [],
+                $baseUrl.'/path/to/child',
+            ],
+            'path without trailing slash, non-empty query' => [
+                $baseUrl,
+                '/path/to/child',
+                ['one' => 'two', 'three' => 'four'],
+                $baseUrl.'/path/to/child?one=two&three=four',
+            ],
+            'path with trailing slash, non-empty query' => [
+                $baseUrl,
+                '/path/to/child/',
+                ['one' => 'two', 'three' => 'four'],
+                $baseUrl.'/path/to/child?one=two&three=four',
+            ],
+            'empty path, non-empty query' => [
+                $baseUrl,
+                '',
+                ['one' => 'two', 'three' => 'four'],
+                $baseUrl.'/?one=two&three=four',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<array-key, array<array-key, string|array<string, string>>>
+     */
+    public function emulatedUrls(): array
+    {
+        $namespace = 'namespace';
+        $baseUrl = 'https://'.$namespace.'.db.tld';
+        $emulatorHost = 'localhost:9000';
+
+        return [
+            'empty path, empty query' => [
+                $emulatorHost,
+                $baseUrl,
+                '',
+                [],
+                'http://'.$emulatorHost.'/?ns=namespace'
+            ],
+            'path without trailing slash, empty query' => [
+                $emulatorHost,
+                $baseUrl,
+                '/path/to/child',
+                [],
+                'http://'.$emulatorHost.'/path/to/child?ns=namespace'
+            ],
+            'path with trailing slash, empty query' => [
+                $emulatorHost,
+                $baseUrl,
+                '/path/to/child/',
+                [],
+                'http://'.$emulatorHost.'/path/to/child?ns=namespace'
+            ],
+            'path without trailing slash, non-empty query' => [
+                $emulatorHost,
+                $baseUrl,
+                '/path/to/child',
+                ['one' => 'two', 'three' => 'four'],
+                'http://'.$emulatorHost.'/path/to/child?ns=namespace&one=two&three=four',
+            ],
+            'path with trailing slash, non-empty query' => [
+                $emulatorHost,
+                $baseUrl,
+                '/path/to/child/',
+                ['one' => 'two', 'three' => 'four'],
+                'http://'.$emulatorHost.'/path/to/child?ns=namespace&one=two&three=four',
+            ],
+            'empty path, non-empty query' => [
+                $emulatorHost,
+                $baseUrl,
+                '',
+                ['one' => 'two', 'three' => 'four'],
+                'http://'.$emulatorHost.'/?ns=namespace&one=two&three=four',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/DatabaseTest.php
+++ b/tests/Unit/DatabaseTest.php
@@ -19,17 +19,18 @@ final class DatabaseTest extends UnitTestCase
 {
     /** @var ApiClient|MockObject */
     private $apiClient;
-
+    private string $url;
     private Uri $uri;
 
     private Database $database;
 
     protected function setUp(): void
     {
-        $this->uri = new Uri('https://database-uri.tld');
+        $this->url = 'https://database.firebaseio.tld';
+        $this->uri = new Uri($this->url);
         $this->apiClient = $this->createMock(ApiClient::class);
 
-        $this->database = new Database($this->uri, $this->apiClient);
+        $this->database = new Database($this->uri, $this->apiClient, Database\UrlBuilder::create($this->url));
     }
 
     public function testGetReference(): void
@@ -50,7 +51,7 @@ final class DatabaseTest extends UnitTestCase
 
     public function testGetReferenceFromUrl(): void
     {
-        $url = 'https://database-uri.tld/foo/bar';
+        $url = $this->url.'/foo/bar';
 
         $this->assertSame($url, (string) $this->database->getReferenceFromUrl($url)->getUri());
     }
@@ -66,7 +67,7 @@ final class DatabaseTest extends UnitTestCase
     {
         $this->apiClient
             ->method('get')
-            ->with($this->uri->withPath('/.settings/rules'))
+            ->with('/.settings/rules')
             ->willReturn($expected = RuleSet::default()->getRules())
         ;
 

--- a/tests/_fixtures/emulator/database.rules.json
+++ b/tests/_fixtures/emulator/database.rules.json
@@ -1,0 +1,6 @@
+{
+    "rules": {
+        ".read": false,
+        ".write": false
+    }
+}


### PR DESCRIPTION
You can similarly use this as you use the Auth Simulator:

* Install and run the Firebase Emulator Suite ([Instructions](https://firebase.google.com/docs/emulator-suite/connect_and_prototype?database=RTDB))
* Set the `FIREBASE_DATABASE_EMULATOR_HOST=localhost:<port>` environment variable

Your application/tests should now work with the RTDB emulator instead of a remote database

:octocat: 

_PS: Don't mind the failing integration tests - the APNS Service likes to barf most of the time. I need to add some "allowed to fail" logic - later._