### PR TITLE
feat: set default http timeouts

### DIFF
--- a/src/Firebase/Http/HttpClientOptions.php
+++ b/src/Firebase/Http/HttpClientOptions.php
@@ -11,7 +11,7 @@ final class HttpClientOptions
     /**
      * The amount of seconds to wait while connecting to a server.
      *
-     * Defaults to indefinitely.
+     * Defaults to 15 seconds.
      */
     private ?float $connectTimeout = 15;
 
@@ -25,7 +25,7 @@ final class HttpClientOptions
     /**
      * The amount of seconds to wait for a full request (connect + transfer + read) to complete.
      *
-     * Defaults to indefinitely.
+     * Defaults to 30 seconds.
      */
     private ?float $timeout = 30;
 

--- a/src/Firebase/Http/HttpClientOptions.php
+++ b/src/Firebase/Http/HttpClientOptions.php
@@ -13,7 +13,7 @@ final class HttpClientOptions
      *
      * Defaults to indefinitely.
      */
-    private ?float $connectTimeout = null;
+    private ?float $connectTimeout = 15;
 
     /**
      * The amount of seconds to wait while reading a streamed body.
@@ -27,7 +27,7 @@ final class HttpClientOptions
      *
      * Defaults to indefinitely.
      */
-    private ?float $timeout = null;
+    private ?float $timeout = 30;
 
     /**
      * The proxy that all requests should be passed through.


### PR DESCRIPTION
ref https://github.com/kreait/laravel-firebase/pull/146

Lets set sensible default timeouts to HTTP client.

I have taken these values from Laravel framework HTTP client.

This should not be a breaking change to existing users since firebase server is not going to wait for us indefinitely.