### PR TITLE
Fix custom token generation with IAM Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* When no Service Account was provided, custom token were generated with a direct call to the Google Identity Toolkit,
+  which could create invalid token signatures depending on the environment (e.g. GCE).
+  Now, the provided credentials are used to sign custom tokens via the 
+  `Kreait\Firebase\Auth\CustomTokenViaGoogleCredentials` class. This is an internal class and should not be used
+  directly.
+  ([#745](https://github.com/kreait/firebase-php/pull/745))
+
+### Deprecated
+
+* `Kreait\Firebase\Auth\CustomTokenViaGoogleIam` (internal)
+
 ## [6.9.2] - 2022-10-17
 
 ### Fixed

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -9,7 +9,7 @@ use DateTimeImmutable;
 use Kreait\Firebase\Auth\ActionCodeSettings;
 use Kreait\Firebase\Auth\ActionCodeSettings\ValidatedActionCodeSettings;
 use Kreait\Firebase\Auth\ApiClient;
-use Kreait\Firebase\Auth\CustomTokenViaGoogleIam;
+use Kreait\Firebase\Auth\CustomTokenViaGoogleCredentials;
 use Kreait\Firebase\Auth\DeleteUsersRequest;
 use Kreait\Firebase\Auth\DeleteUsersResult;
 use Kreait\Firebase\Auth\SendActionLink\FailedToSendActionLink;
@@ -62,14 +62,14 @@ final class Auth implements Contract\Auth
 {
     private ApiClient $client;
 
-    /** @var CustomTokenGenerator|CustomTokenViaGoogleIam|null */
+    /** @var CustomTokenGenerator|CustomTokenViaGoogleCredentials|null */
     private $tokenGenerator;
     private IdTokenVerifier $idTokenVerifier;
     private SessionCookieVerifier $sessionCookieVerifier;
     private ClockInterface $clock;
 
     /**
-     * @param CustomTokenGenerator|CustomTokenViaGoogleIam|null $tokenGenerator
+     * @param CustomTokenGenerator|CustomTokenViaGoogleCredentials|null $tokenGenerator
      */
     public function __construct(
         ApiClient $client,
@@ -372,7 +372,7 @@ final class Auth implements Contract\Auth
 
         if ($generator instanceof CustomTokenGenerator) {
             $tokenString = $generator->createCustomToken($uid, $claims, $ttl)->toString();
-        } elseif ($generator instanceof CustomTokenViaGoogleIam) {
+        } elseif ($generator instanceof CustomTokenViaGoogleCredentials) {
             $expiresAt = $this->clock->now()->add(Duration::make($ttl)->value());
 
             $tokenString = $generator->createCustomToken($uid, $claims, $expiresAt)->toString();

--- a/src/Firebase/Auth/CustomTokenViaGoogleCredentials.php
+++ b/src/Firebase/Auth/CustomTokenViaGoogleCredentials.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Auth;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Google\Auth\SignBlobInterface;
+use Kreait\Firebase\Exception\Auth\AuthError;
+use Kreait\Firebase\Util\DT;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Token\Parser;
+use Stringable;
+
+/**
+ * @internal
+ */
+final class CustomTokenViaGoogleCredentials
+{
+    private SignBlobInterface $signer;
+    private ?string $tenantId;
+    private JoseEncoder $encoder;
+    private Parser $parser;
+
+    public function __construct(SignBlobInterface $signer, ?string $tenantId = null)
+    {
+        $this->signer = $signer;
+        $this->tenantId = $tenantId;
+        $this->encoder = new JoseEncoder();
+        $this->parser = new Parser($this->encoder);
+    }
+
+    /**
+     * @param Stringable|string $uid
+     * @param array<string, mixed> $claims
+     *
+     * @throws AuthError
+     */
+    public function createCustomToken($uid, array $claims = [], ?DateTimeInterface $expiresAt = null): Token
+    {
+        $now = new DateTimeImmutable();
+        $expiresAt = ($expiresAt !== null)
+            ? DT::toUTCDateTimeImmutable($expiresAt)
+            : $now->add(new DateInterval('PT1H'));
+
+        $header = ['typ' => 'JWT', 'alg' => 'RS256'];
+        $payload = [
+            'iss' => $this->signer->getClientName(),
+            'sub' => $this->signer->getClientName(),
+            'aud' => 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit',
+            'iat' => $now->getTimestamp(),
+            'exp' => $expiresAt->getTimestamp(),
+            'uid' => (string) $uid,
+        ];
+
+        if ($this->tenantId !== null) {
+            $payload['tenant_id'] = $this->tenantId;
+        }
+
+        if ($claims !== []) {
+            $payload['claims'] = $claims;
+        }
+
+        $base64UrlHeader = $this->base64EncodeArray($header);
+        $base64UrlPayload = $this->base64EncodeArray($payload);
+
+        $signature = $this->signer->signBlob($base64UrlHeader.'.'.$base64UrlPayload);
+        $signature = str_replace(['=', '+', '/'], ['', '-', '_'], $signature);
+
+        return $this->parser->parse(sprintf('%s.%s.%s', $base64UrlHeader, $base64UrlPayload, $signature));
+    }
+
+    /**
+     * @param array<mixed> $array
+     */
+    private function base64EncodeArray(array $array): string
+    {
+        return $this->encoder->base64UrlEncode($this->encoder->jsonEncode($array));
+    }
+}

--- a/src/Firebase/Auth/CustomTokenViaGoogleIam.php
+++ b/src/Firebase/Auth/CustomTokenViaGoogleIam.php
@@ -24,6 +24,8 @@ use function base64_encode;
 
 /**
  * @internal
+ *
+ * @deprecated 6.9.3
  */
 final class CustomTokenViaGoogleIam
 {

--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -23,9 +23,8 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Psr7\Utils as GuzzleUtils;
 use GuzzleHttp\RequestOptions;
-use Kreait\Firebase;
 use Kreait\Firebase\Auth\ApiClient;
-use Kreait\Firebase\Auth\CustomTokenViaGoogleIam;
+use Kreait\Firebase\Auth\CustomTokenViaGoogleCredentials;
 use Kreait\Firebase\Auth\SignIn\GuzzleHandler;
 use Kreait\Firebase\Database\UrlBuilder;
 use Kreait\Firebase\Exception\InvalidArgumentException;
@@ -621,10 +620,12 @@ final class Factory
     }
 
     /**
-     * @return CustomTokenGenerator|CustomTokenViaGoogleIam|null
+     * @return CustomTokenGenerator|CustomTokenViaGoogleCredentials|null
      */
     private function createCustomTokenGenerator()
     {
+        $credentials = $this->getGoogleAuthTokenCredentials();
+
         $serviceAccount = $this->getServiceAccount();
         $clientEmail = $this->getClientEmail();
         $privateKey = $serviceAccount !== null ? $serviceAccount->getPrivateKey() : null;
@@ -639,8 +640,8 @@ final class Factory
             return $generator->withTenantId($this->tenantId);
         }
 
-        if ($clientEmail !== null) {
-            return new CustomTokenViaGoogleIam($clientEmail, $this->createApiClient(), $this->tenantId);
+        if ($credentials instanceof SignBlobInterface) {
+            return new CustomTokenViaGoogleCredentials($credentials, $this->tenantId);
         }
 
         return null;

--- a/src/Firebase/RemoteConfig/Template.php
+++ b/src/Firebase/RemoteConfig/Template.php
@@ -173,9 +173,9 @@ class Template implements JsonSerializable
      */
     public function conditionNames(): array
     {
-        return array_unique(
+        return array_values(array_unique(
             array_map(static fn (Condition $c) => $c->name(), $this->conditions),
-        );
+        ));
     }
 
     /**

--- a/src/Firebase/Request/UpdateUser.php
+++ b/src/Firebase/Request/UpdateUser.php
@@ -12,6 +12,7 @@ use Stringable;
 use function array_reduce;
 use function array_unique;
 use function is_array;
+use function is_string;
 use function mb_strtolower;
 use function preg_replace;
 
@@ -75,7 +76,17 @@ final class UpdateUser implements Request
                 case 'deleteattribute':
                 case 'deleteattributes':
                     foreach ((array) $value as $deleteAttribute) {
-                        switch (mb_strtolower(preg_replace('/[^a-z]/i', '', $deleteAttribute))) {
+                        if (!is_string($deleteAttribute) || $deleteAttribute === '') {
+                            continue;
+                        }
+
+                        $deleteAttribute = preg_replace('/[^a-z]/i', '', $deleteAttribute);
+
+                        if ($deleteAttribute === null) {
+                            continue;
+                        }
+
+                        switch (mb_strtolower($deleteAttribute)) {
                             case 'displayname':
                                 $request = $request->withRemovedDisplayName();
 

--- a/tests/Integration/Auth/CustomTokenViaGoogleCredentialsTest.php
+++ b/tests/Integration/Auth/CustomTokenViaGoogleCredentialsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Integration\Auth;
+
+use Google\Auth\CredentialsLoader;
+use Google\Auth\SignBlobInterface;
+use Kreait\Firebase\Auth\CustomTokenViaGoogleCredentials;
+use Kreait\Firebase\Contract\Auth;
+use Kreait\Firebase\Factory;
+use Kreait\Firebase\Tests\IntegrationTestCase;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\UnencryptedToken;
+
+/**
+ * @internal
+ */
+final class CustomTokenViaGoogleCredentialsTest extends IntegrationTestCase
+{
+    private string $uid = 'some-uid';
+    private CustomTokenViaGoogleCredentials $generator;
+    private Auth $auth;
+
+    protected function setUp(): void
+    {
+        $credentials = CredentialsLoader::makeCredentials(Factory::API_CLIENT_SCOPES, self::$serviceAccount->asArray());
+
+        if (!$credentials instanceof SignBlobInterface) {
+            $this->markTestSkipped('No credential capable of signing custom tokens found');
+        }
+
+        $this->generator = new CustomTokenViaGoogleCredentials($credentials);
+        $this->auth = self::$factory->createAuth();
+    }
+
+    public function testCreateCustomToken(): void
+    {
+        $token = $this->generator->createCustomToken($this->uid, ['a-claim' => 'a-value']);
+
+        $check = $this->auth->signInWithCustomToken($token);
+
+        $this->assertSame($this->uid, $check->firebaseUserId());
+    }
+
+    public function testAGeneratedCustomTokenCanBeParsed(): void
+    {
+        $token = $this->generator->createCustomToken($this->uid, ['a-claim' => 'a-value']);
+
+        $tokenString = trim($token->toString(), '=');
+        $parsed = (new Parser(new JoseEncoder()))->parse($tokenString);
+
+        $this->assertInstanceOf(UnencryptedToken::class, $parsed);
+        $this->assertSame($this->uid, $parsed->claims()->get('uid'));
+    }
+}


### PR DESCRIPTION
Fixes #743 

### How to test

Insert/Update the `require` section in your project's  `composer.json`:

```json5
{
    "require": {
        "kreait/firebase-php": "dev-743-custom-token-via-iam"
    }
}
```
and run `composer update -W`

Then, deploy the project to the environment where custom token generation didn't work before (e.g. GCE) and try generating a custom token with the `$auth->createCustomToken()` method, and use it in your frontend application to sign a user in (or use the `$auth->signInWithCustomToken()` method.

:octocat: