### PR TITLE
Attach errors to NotFound exception to be able to always have the full error response available

### DIFF
--- a/src/Firebase/Messaging.php
+++ b/src/Firebase/Messaging.php
@@ -58,7 +58,7 @@ final class Messaging implements Contract\Messaging
             $token = Json::decode(Json::encode($message), true)['token'] ?? null;
 
             if ($token) {
-                throw NotFound::becauseTokenNotFound($token);
+                throw NotFound::becauseTokenNotFound($token, $e->errors());
             }
 
             throw $e;
@@ -189,8 +189,8 @@ final class Messaging implements Contract\Messaging
 
         try {
             return $this->appInstanceApi->getAppInstanceAsync($token)->wait();
-        } catch (NotFound) {
-            throw NotFound::becauseTokenNotFound($token->value());
+        } catch (NotFound $e) {
+            throw NotFound::becauseTokenNotFound($token->value(), $e->errors());
         } catch (MessagingException $e) {
             // The token is invalid
             throw new InvalidArgument("The registration token '{$token}' is invalid or not available", $e->getCode(), $e);


### PR DESCRIPTION
Hello, I was a bit confused when looking at the NotFound Exception because the errors() method always returned an empty array. After a bit of research I found that you catched that specific exception in Messaging.php and created a new NotFound, but lost the errors array that was previously created by convertResponse(). A simple fix is to add back the errors  to becauseTokenNotFound().
I only tested this in 5.x because of limitations (php 7.4 and Guzzle 6), but the problem seems to also be in 7.x.