### PR TITLE
Fix broken apns background message data detection

### DIFF
--- a/src/Firebase/Messaging/Processor/SetApnsContentAvailableIfNeeded.php
+++ b/src/Firebase/Messaging/Processor/SetApnsContentAvailableIfNeeded.php
@@ -35,12 +35,9 @@ final class SetApnsContentAvailableIfNeeded
         $messageData = $this->getMessageData($payload);
         $apnsData = $apnsConfig->data();
 
-        if ($apnsData === []) {
-            // No data, no 'content-available' field
-            return $message;
-        }
+        $hasData = $messageData->toArray() !== [] || $apnsData !== [];
 
-        if ($messageData->toArray() === []) {
+        if (!$hasData) {
             // No data, no 'content-available' field
             return $message;
         }

--- a/src/Firebase/Messaging/Processor/SetApnsPushTypeIfNeeded.php
+++ b/src/Firebase/Messaging/Processor/SetApnsPushTypeIfNeeded.php
@@ -92,8 +92,7 @@ final class SetApnsPushTypeIfNeeded
         if (!is_array($payload['data'])) {
             return MessageData::fromArray([]);
         }
-        MessageData::fromArray($payload['data']);
 
-        return MessageData::fromArray([]);
+        return MessageData::fromArray($payload['data']);
     }
 }


### PR DESCRIPTION
# Description

Hi there, 

A change introduced in 6.9.0, in this [commit](https://github.com/kreait/firebase-php/commit/8d7fa90c7b1ea65fffb92d283ef482b08c754b32#diff-e4d74dac127d717e2e5a2afab1f2051885e5d2be1da9c458f5abb87ec1f0604a), has broken APNS background messages (data only).

The broken code in [src/Firebase/Messaging/Processor/SetApnsPushTypeIfNeeded.php L95](https://github.com/kreait/firebase-php/blob/b7ea6e00d027c29a5321ba5b4d76a6ef04880f67/src/Firebase/Messaging/Processor/SetApnsPushTypeIfNeeded.php#L95) has since been fixed in 7.x but not backported to 6.x which we use (we cannot upgrade to 7.x just yet due to PHP version requirement). This code was always returning an empty MessageData even when data was detected in the payload.

The broken data detection in [src/Firebase/Messaging/Processor/SetApnsContentAvailableIfNeeded.php L38-43](https://github.com/kreait/firebase-php/blob/b7ea6e00d027c29a5321ba5b4d76a6ef04880f67/src/Firebase/Messaging/Processor/SetApnsContentAvailableIfNeeded.php#L38) is still an issue in 7.x and the fix probably needs to be backported. This code never adds the "content-available" APNS field without apnsData, even when messageData is not empty (which is our case and how we detected the bug). 

I would really appreciate a quick merge & release if you find the PR sufficient, we had to revert to 6.8.0 in the meantime as this broke our iOS background data sync.

Let me know if you need me to do anything else.
Cheers
Marc

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
