### PR TITLE
Link to updated non-gRPC firebase package

### DIFF
--- a/docs/cloud-firestore.rst
+++ b/docs/cloud-firestore.rst
@@ -15,7 +15,7 @@ package. You can enable the component in the SDK by adding the package to your p
     projects aim to provide support for Firestore without the need to install the gRPC PHP extension, but have to
     be set up separately:
 
-    - `ahsankhatri/firestore-php <https://github.com/ahsankhatri/firestore-php>`_
+    - `bensontrent/firestore-php <https://github.com/bensontrent/firestore-php>`_
     - `morrislaptop/firestore-php <https://github.com/morrislaptop/firestore-php>`_
 
 Before you start, please read about Firestore in the official documentation:


### PR DESCRIPTION
This is a proposal to link to an updated version of ahsakharti/firestore-php.  The ahsakharti/firestore-php  (https://github.com/ahsankhatri/firestore-php) package has been archived, and it is difficult to install.  I've forked the original project and updated it to support Guzzle 7 and PHP 7/8. I fixed a few minor bugs for php 8 compatibility, and improved the documentation.  It has been published https://packagist.org and is installable with `composer require bensontrent/firestore-php`.

# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context._

Fixes # (issue)
or
Closes # (issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
