### PR TITLE
docs: updated app-check docs, fixed typo

### DIFF
--- a/docs/app-check.rst
+++ b/docs/app-check.rst
@@ -38,7 +38,7 @@ Initializing the App Check component
 
 .. code-block:: php
 
-    $auth = app('firebase.app_check');
+    $appCheck = app('firebase.app_check');
 
 
 .. _verify-app-check-tokens:


### PR DESCRIPTION
# Description

The **AppCheck** documentation had a typo in it, a little copy-pasta from the auth docs.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
