### PR TITLE
Add support for Remote Config Parameter Value Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ## [Unreleased]
 
-### Changed
+### Added
+* 
+* Added support for [Parameter Value Types](https://firebase.google.com/docs/reference/remote-config/rest/v1/RemoteConfig#parametervaluetype)
+  when getting and setting a RemoteConfig template.
+  ([Documentation](https://firebase-php.readthedocs.io/en/latest/remote-config.html#parameter-value-types))
 
-#### RemoteConfig
+### Deprecated
 
-* Introduced `Kreait\Firebase\RemoteConfig\ParameterValue` to be used instead of the explicit classes 
-  `Kreait\Firebase\RemoteConfig\ExplicitValue` and `Kreait\Firebase\RemoteConfig\DefaultValue`
-  * `Kreait\Firebase\RemoteConfig\DefaultValue` should be regarded as deprecated, it is kept to not
-    create a breaking change
-  * `Kreait\Firebase\RemoteConfig\ExplicitValue` is deprecated
+* `Kreait\Firebase\RemoteConfig\ExplicitValue` is deprecated
+* `Kreait\Firebase\RemoteConfig\DefaultValue` should be regarded as deprecated, it is kept to not create a breaking changes
 
 ## [7.3.1] - 2023-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+#### RemoteConfig
+
+* Introduced `Kreait\Firebase\RemoteConfig\ParameterValue` to be used instead of the explicit classes 
+  `Kreait\Firebase\RemoteConfig\ExplicitValue` and `Kreait\Firebase\RemoteConfig\DefaultValue`
+  * `Kreait\Firebase\RemoteConfig\DefaultValue` should be regarded as deprecated, it is kept to not
+    create a breaking change
+  * `Kreait\Firebase\RemoteConfig\ExplicitValue` is deprecated
+
 ## [7.3.1] - 2023-06-10
 
 ### Changed

--- a/docs/remote-config.rst
+++ b/docs/remote-config.rst
@@ -103,11 +103,40 @@ Add a parameter
 .. code-block:: php
 
     use Kreait\Firebase\RemoteConfig;
+    use Kreait\Firebase\RemoteConfig\ParameterValueType;
 
     $welcomeMessageParameter = RemoteConfig\Parameter::named('welcome_message')
             ->withDefaultValue('Welcome!')
             ->withDescription('This is a welcome message') // optional
+            ->withValueType(ParameterValueType $valueType): self
     ;
+
+Parameter Value Types
+---------------------
+
+.. note::
+    Support for Parameter Value Types has been added in version 7.4.0 of the SDK
+
+.. code-block:: php
+
+    use Kreait\Firebase\RemoteConfig\Parameter;
+    use Kreait\Firebase\RemoteConfig\ParameterValueType;
+
+    Parameter::named('string_parameter')
+        ->withDefaultValue('Welcome!')
+        ->withValueType(ParameterValueType::STRING);
+
+    Parameter::named('boolean_parameter')
+        ->withDefaultValue('true')
+        ->withValueType(ParameterValueType::BOOL);
+
+    Parameter::named('numeric_parameter')
+        ->withDefaultValue('5')
+        ->withValueType(ParameterValueType::NUMBER);
+
+    Parameter::named('json_parameter')
+        ->withDefaultValue('{"foo": "bar"}')
+        ->withValueType(ParameterValueType::JSON);
 
 ******************
 Conditional values

--- a/src/Firebase/RemoteConfig/ConditionalValue.php
+++ b/src/Firebase/RemoteConfig/ConditionalValue.php
@@ -6,12 +6,11 @@ namespace Kreait\Firebase\RemoteConfig;
 
 use JsonSerializable;
 
+use function is_array;
 use function is_string;
 
 /**
- * @phpstan-import-type RemoteConfigPersonalizationValueShape from PersonalizationValue
- * @phpstan-import-type RemoteConfigExplicitValueShape from ExplicitValue
- * @phpstan-import-type RemoteConfigInAppDefaultValueShape from DefaultValue
+ * @phpstan-import-type RemoteConfigParameterValueShape from ParameterValue
  */
 class ConditionalValue implements JsonSerializable
 {
@@ -19,9 +18,8 @@ class ConditionalValue implements JsonSerializable
      * @internal
      *
      * @param non-empty-string $conditionName
-     * @param RemoteConfigExplicitValueShape|RemoteConfigInAppDefaultValueShape|RemoteConfigPersonalizationValueShape|string $data
      */
-    public function __construct(private readonly string $conditionName, private readonly array|string $data)
+    public function __construct(private readonly string $conditionName, private readonly ParameterValue $value)
     {
     }
 
@@ -40,37 +38,52 @@ class ConditionalValue implements JsonSerializable
     {
         $name = $condition instanceof Condition ? $condition->name() : $condition;
 
-        return new self($name, ['value' => '']);
+        return new self($name, ParameterValue::withValue(''));
     }
 
     /**
-     * @return RemoteConfigExplicitValueShape|RemoteConfigInAppDefaultValueShape|RemoteConfigPersonalizationValueShape|string
+     * @return RemoteConfigParameterValueShape|string
      */
     public function value()
     {
-        return $this->data;
+        $data = $this->value->toArray();
+
+        $valueString = $data['value'] ?? null;
+
+        if ($valueString !== null) {
+            return $valueString;
+        }
+
+        return $data;
     }
 
     /**
-     * @param RemoteConfigExplicitValueShape|RemoteConfigInAppDefaultValueShape|RemoteConfigPersonalizationValueShape|string $value
+     * @param ParameterValue|RemoteConfigParameterValueShape|string $value
      */
     public function withValue($value): self
     {
+        if (is_string($value)) {
+            return new self($this->conditionName, ParameterValue::withValue($value));
+        }
+
+        if (is_array($value)) {
+            return new self($this->conditionName, ParameterValue::fromArray($value));
+        }
+
         return new self($this->conditionName, $value);
     }
 
     /**
-     * @return RemoteConfigExplicitValueShape|RemoteConfigInAppDefaultValueShape|RemoteConfigPersonalizationValueShape
+     * @return RemoteConfigParameterValueShape
      */
     public function toArray(): array
     {
-        if (is_string($this->data)) {
-            return ExplicitValue::fromString($this->data)->toArray();
-        }
-
-        return $this->data;
+        return $this->value->toArray();
     }
 
+    /**
+     * @return RemoteConfigParameterValueShape
+     */
     public function jsonSerialize(): array
     {
         return $this->toArray();

--- a/src/Firebase/RemoteConfig/DefaultValue.php
+++ b/src/Firebase/RemoteConfig/DefaultValue.php
@@ -10,6 +10,7 @@ use JsonSerializable;
  * @phpstan-import-type RemoteConfigParameterValueShape from ParameterValue
  *
  * @todo Deprecate/Remove in 8.0
+ * @see ParameterValue
  */
 class DefaultValue implements JsonSerializable
 {

--- a/src/Firebase/RemoteConfig/DefaultValue.php
+++ b/src/Firebase/RemoteConfig/DefaultValue.php
@@ -7,50 +7,47 @@ namespace Kreait\Firebase\RemoteConfig;
 use JsonSerializable;
 
 /**
- * @phpstan-import-type RemoteConfigPersonalizationValueShape from PersonalizationValue
- * @phpstan-import-type RemoteConfigExplicitValueShape from ExplicitValue
+ * @phpstan-import-type RemoteConfigParameterValueShape from ParameterValue
  *
- * @phpstan-type RemoteConfigInAppDefaultValueShape array{
- *     useInAppDefault: bool
- * }
+ * @todo Deprecate/Remove in 8.0
  */
 class DefaultValue implements JsonSerializable
 {
-    /**
-     * @param RemoteConfigExplicitValueShape|RemoteConfigInAppDefaultValueShape|RemoteConfigPersonalizationValueShape $data
-     */
-    private function __construct(private readonly array $data)
+    private function __construct(private readonly ParameterValue $value)
     {
     }
 
     public static function useInAppDefault(): self
     {
-        return new self(['useInAppDefault' => true]);
+        return new self(ParameterValue::inAppDefault());
     }
 
     public static function with(string $value): self
     {
-        return new self(['value' => $value]);
+        return new self(ParameterValue::withValue($value));
     }
 
     /**
-     * @return RemoteConfigExplicitValueShape|RemoteConfigInAppDefaultValueShape|RemoteConfigPersonalizationValueShape
-     */
-    public function toArray(): array
-    {
-        return $this->data;
-    }
-
-    /**
-     * @param RemoteConfigExplicitValueShape|RemoteConfigInAppDefaultValueShape|RemoteConfigPersonalizationValueShape $data
+     * @param RemoteConfigParameterValueShape $data
      */
     public static function fromArray(array $data): self
     {
-        return new self($data);
+        return new self(ParameterValue::fromArray($data));
     }
 
+    /**
+     * @return RemoteConfigParameterValueShape
+     */
+    public function toArray(): array
+    {
+        return $this->value->toArray();
+    }
+
+    /**
+     * @return RemoteConfigParameterValueShape
+     */
     public function jsonSerialize(): array
     {
-        return $this->data;
+        return $this->toArray();
     }
 }

--- a/src/Firebase/RemoteConfig/ExplicitValue.php
+++ b/src/Firebase/RemoteConfig/ExplicitValue.php
@@ -7,6 +7,10 @@ namespace Kreait\Firebase\RemoteConfig;
 use JsonSerializable;
 
 /**
+ * @deprecated 7.4.0
+ *
+ * @codeCoverageIgnore
+ *
  * @phpstan-type RemoteConfigExplicitValueShape array{
  *     value: string
  * }

--- a/src/Firebase/RemoteConfig/Parameter.php
+++ b/src/Firebase/RemoteConfig/Parameter.php
@@ -13,26 +13,24 @@ use function is_string;
  * @phpstan-import-type RemoteConfigParameterValueShape from ParameterValue
  *
  * @phpstan-type RemoteConfigParameterShape array{
- *     defaultValue?: RemoteConfigParameterValueShape,
- *     conditionalValues?: array<non-empty-string, RemoteConfigParameterValueShape>,
- *     description?: string
+ *     description?: string|null,
+ *     defaultValue?: RemoteConfigParameterValueShape|null,
+ *     conditionalValues?: array<non-empty-string, RemoteConfigParameterValueShape>|null,
+ *     valueType?: non-empty-string|null
  * }
  */
 class Parameter implements JsonSerializable
 {
-    private ?string $description = '';
-
-    /**
-     * @var list<ConditionalValue>
-     */
-    private array $conditionalValues = [];
-
     /**
      * @param non-empty-string $name
+     * @param list<ConditionalValue> $conditionalValues
      */
     private function __construct(
         private readonly string $name,
-        private ?ParameterValue $defaultValue = null,
+        private readonly string $description,
+        private readonly ?ParameterValue $defaultValue,
+        private readonly array $conditionalValues,
+        private readonly ParameterValueType $valueType,
     ) {
     }
 
@@ -40,25 +38,41 @@ class Parameter implements JsonSerializable
      * @param non-empty-string $name
      * @param DefaultValue|RemoteConfigParameterValueShape|string|bool|null $defaultValue
      */
-    public static function named(string $name, $defaultValue = null): self
+    public static function named(string $name, $defaultValue = null, ?ParameterValueType $valueType = null): self
+    {
+        $defaultValue = self::mapDefaultValue($defaultValue);
+
+        return new self(
+            name: $name,
+            description: '',
+            defaultValue: $defaultValue,
+            conditionalValues: [],
+            valueType: $valueType ?? ParameterValueType::UNSPECIFIED,
+        );
+    }
+
+    /**
+     * @param DefaultValue|RemoteConfigParameterValueShape|string|bool|null $defaultValue
+     */
+    private static function mapDefaultValue($defaultValue): ?ParameterValue
     {
         if ($defaultValue === null) {
-            return new self($name, null);
+            return null;
         }
 
         if ($defaultValue instanceof DefaultValue) {
-            return new self($name, ParameterValue::fromArray($defaultValue->toArray()));
+            return ParameterValue::fromArray($defaultValue->toArray());
         }
 
         if (is_string($defaultValue)) {
-            return new self($name, ParameterValue::withValue($defaultValue));
+            return ParameterValue::withValue($defaultValue);
         }
 
         if (is_bool($defaultValue)) {
-            return new self($name, ParameterValue::inAppDefault());
+            return ParameterValue::inAppDefault();
         }
 
-        return new self($name, ParameterValue::fromArray($defaultValue));
+        return ParameterValue::fromArray($defaultValue);
     }
 
     /**
@@ -71,15 +85,18 @@ class Parameter implements JsonSerializable
 
     public function description(): string
     {
-        return $this->description ?: '';
+        return $this->description;
     }
 
     public function withDescription(string $description): self
     {
-        $parameter = clone $this;
-        $parameter->description = $description;
-
-        return $parameter;
+        return new self(
+            name: $this->name,
+            description: $description,
+            defaultValue: $this->defaultValue,
+            conditionalValues: $this->conditionalValues,
+            valueType: $this->valueType,
+        );
     }
 
     /**
@@ -87,9 +104,20 @@ class Parameter implements JsonSerializable
      */
     public function withDefaultValue($defaultValue): self
     {
-        return self::named($this->name, $defaultValue);
+        $defaultValue = self::mapDefaultValue($defaultValue);
+
+        return new self(
+            name: $this->name,
+            description: $this->description,
+            defaultValue: $defaultValue,
+            conditionalValues: $this->conditionalValues,
+            valueType: $this->valueType,
+        );
     }
 
+    /**
+     * @todo 8.0 Replace with `ParameterValue`
+     */
     public function defaultValue(): ?DefaultValue
     {
         if ($this->defaultValue === null) {
@@ -101,10 +129,16 @@ class Parameter implements JsonSerializable
 
     public function withConditionalValue(ConditionalValue $conditionalValue): self
     {
-        $parameter = clone $this;
-        $parameter->conditionalValues[] = $conditionalValue;
+        $conditionalValues = $this->conditionalValues;
+        $conditionalValues[] = $conditionalValue;
 
-        return $parameter;
+        return new self(
+            name: $this->name,
+            description: $this->description,
+            defaultValue: $this->defaultValue,
+            conditionalValues: $conditionalValues,
+            valueType: $this->valueType,
+        );
     }
 
     /**
@@ -113,6 +147,22 @@ class Parameter implements JsonSerializable
     public function conditionalValues(): array
     {
         return $this->conditionalValues;
+    }
+
+    public function withValueType(ParameterValueType $valueType): self
+    {
+        return new self(
+            name: $this->name,
+            description: $this->description,
+            defaultValue: $this->defaultValue,
+            conditionalValues: $this->conditionalValues,
+            valueType: $valueType,
+        );
+    }
+
+    public function valueType(): ParameterValueType
+    {
+        return $this->valueType;
     }
 
     /**
@@ -136,9 +186,11 @@ class Parameter implements JsonSerializable
             $array['conditionalValues'] = $conditionalValues;
         }
 
-        if ($this->description !== null && $this->description !== '') {
+        if ($this->description !== '') {
             $array['description'] = $this->description;
         }
+
+        $array['valueType'] = $this->valueType->value;
 
         return $array;
     }

--- a/src/Firebase/RemoteConfig/ParameterValue.php
+++ b/src/Firebase/RemoteConfig/ParameterValue.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+use JsonSerializable;
+
+use function array_key_exists;
+
+/**
+ * @phpstan-import-type RemoteConfigPersonalizationValueShape from PersonalizationValue
+ *
+ * @phpstan-type RemoteConfigParameterValueShape array{
+ *     value?: string,
+ *     useInAppDefault?: bool,
+ *     personalizationValue?: RemoteConfigPersonalizationValueShape
+ * }
+ */
+final class ParameterValue implements JsonSerializable
+{
+    private function __construct(
+        private ?string $value = null,
+        private ?bool $useInAppDefault = null,
+        private ?PersonalizationValue $personalizationValue = null,
+    ) {
+    }
+
+    public static function withValue(string $value): self
+    {
+        return new self(value: $value);
+    }
+
+    public static function inAppDefault(): self
+    {
+        return new self(useInAppDefault: true);
+    }
+
+    public static function withPersonalizationValue(PersonalizationValue $value): self
+    {
+        return new self(personalizationValue: $value);
+    }
+
+    /**
+     * @param RemoteConfigParameterValueShape $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (array_key_exists('value', $data)) {
+            return self::withValue($data['value']);
+        }
+
+        if (array_key_exists('useInAppDefault', $data)) {
+            return self::inAppDefault();
+        }
+
+        if (array_key_exists('personalizationValue', $data)) {
+            return self::withPersonalizationValue(PersonalizationValue::fromArray($data['personalizationValue']));
+        }
+
+        return new self();
+    }
+
+    /**
+     * @return RemoteConfigParameterValueShape
+     */
+    public function toArray(): array
+    {
+        if ($this->value !== null) {
+            return ['value' => $this->value];
+        }
+
+        if ($this->useInAppDefault !== null) {
+            return ['useInAppDefault' => $this->useInAppDefault];
+        }
+
+        if ($this->personalizationValue !== null) {
+            return ['personalizationValue' => $this->personalizationValue->toArray()];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return RemoteConfigParameterValueShape
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Firebase/RemoteConfig/ParameterValueType.php
+++ b/src/Firebase/RemoteConfig/ParameterValueType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\RemoteConfig;
+
+/**
+ * @see https://firebase.google.com/docs/reference/remote-config/rest/v1/RemoteConfig#ParameterValueType
+ */
+enum ParameterValueType: string
+{
+    case UNSPECIFIED = 'PARAMETER_VALUE_TYPE_UNSPECIFIED';
+
+    case STRING = 'STRING';
+
+    case BOOL = 'BOOLEAN';
+
+    case NUMBER = 'NUMBER';
+
+    case JSON = 'JSON';
+}

--- a/src/Firebase/RemoteConfig/PersonalizationValue.php
+++ b/src/Firebase/RemoteConfig/PersonalizationValue.php
@@ -28,8 +28,19 @@ final class PersonalizationValue implements JsonSerializable
         return new self($data);
     }
 
-    public function jsonSerialize(): array
+    /**
+     * @return RemoteConfigPersonalizationValueShape
+     */
+    public function toArray(): array
     {
         return $this->data;
+    }
+
+    /**
+     * @return RemoteConfigPersonalizationValueShape
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 }

--- a/src/Firebase/RemoteConfig/Template.php
+++ b/src/Firebase/RemoteConfig/Template.php
@@ -8,7 +8,6 @@ use JsonSerializable;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 
 use function array_filter;
-use function array_key_exists;
 use function array_map;
 use function array_unique;
 use function array_values;
@@ -227,15 +226,13 @@ class Template implements JsonSerializable
      */
     private static function buildParameter(string $name, array $data): Parameter
     {
-        $parameter = Parameter::named($name)->withDescription((string) ($data['description'] ?? ''));
-
-        // @phpstan-ignore-next-line
-        if (array_key_exists('defaultValue', $data) && $data['defaultValue'] !== null) {
-            $parameter = $parameter->withDefaultValue(DefaultValue::fromArray($data['defaultValue']));
-        }
+        $parameter = Parameter::named($name)
+            ->withDescription((string) ($data['description'] ?? ''))
+            ->withDefaultValue($data['defaultValue'] ?? null)
+        ;
 
         foreach ((array) ($data['conditionalValues'] ?? []) as $key => $conditionalValueData) {
-            $parameter = $parameter->withConditionalValue(new ConditionalValue($key, $conditionalValueData));
+            $parameter = $parameter->withConditionalValue(new ConditionalValue($key, ParameterValue::fromArray($conditionalValueData)));
         }
 
         return $parameter;

--- a/src/Firebase/RemoteConfig/Template.php
+++ b/src/Firebase/RemoteConfig/Template.php
@@ -226,9 +226,12 @@ class Template implements JsonSerializable
      */
     private static function buildParameter(string $name, array $data): Parameter
     {
+        $valueType = ParameterValueType::tryFrom($data['valueType'] ?? '') ?? ParameterValueType::UNSPECIFIED;
+
         $parameter = Parameter::named($name)
             ->withDescription((string) ($data['description'] ?? ''))
             ->withDefaultValue($data['defaultValue'] ?? null)
+            ->withValueType($valueType)
         ;
 
         foreach ((array) ($data['conditionalValues'] ?? []) as $key => $conditionalValueData) {

--- a/tests/Unit/RemoteConfig/DefaultValueTest.php
+++ b/tests/Unit/RemoteConfig/DefaultValueTest.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Tests\Unit\RemoteConfig;
 
 use Kreait\Firebase\RemoteConfig\DefaultValue;
-use Kreait\Firebase\RemoteConfig\ExplicitValue;
-use Kreait\Firebase\RemoteConfig\PersonalizationValue;
+use Kreait\Firebase\RemoteConfig\ParameterValue;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -14,9 +13,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @internal
  *
- * @phpstan-import-type RemoteConfigPersonalizationValueShape from PersonalizationValue
- * @phpstan-import-type RemoteConfigExplicitValueShape from ExplicitValue
- * @phpstan-import-type RemoteConfigInAppDefaultValueShape from DefaultValue
+ * @phpstan-import-type RemoteConfigParameterValueShape from ParameterValue
  */
 final class DefaultValueTest extends TestCase
 {
@@ -37,8 +34,8 @@ final class DefaultValueTest extends TestCase
     }
 
     /**
-     * @param RemoteConfigInAppDefaultValueShape $expected
-     * @param RemoteConfigInAppDefaultValueShape $data
+     * @param RemoteConfigParameterValueShape $expected
+     * @param RemoteConfigParameterValueShape $data
      */
     #[DataProvider('arrayValueProvider')]
     #[Test]
@@ -50,7 +47,7 @@ final class DefaultValueTest extends TestCase
     }
 
     /**
-     * @return iterable<non-empty-string, array<RemoteConfigInAppDefaultValueShape|RemoteConfigExplicitValueShape|RemoteConfigPersonalizationValueShape>>
+     * @return iterable<non-empty-string, array<RemoteConfigParameterValueShape>>
      */
     public static function arrayValueProvider(): iterable
     {
@@ -60,13 +57,13 @@ final class DefaultValueTest extends TestCase
         ];
 
         yield 'explicit' => [
-            ['value' => '1'],
-            ['value' => '1'],
+            ['value' => 'value'],
+            ['value' => 'value'],
         ];
 
         yield 'personalization' => [
-            ['personalizationId' => 'pid'],
-            ['personalizationId' => 'pid'],
+            ['personalizationValue' => ['personalizationId' => 'pid']],
+            ['personalizationValue' => ['personalizationId' => 'pid']],
         ];
     }
 }

--- a/tests/Unit/RemoteConfig/TemplateTest.php
+++ b/tests/Unit/RemoteConfig/TemplateTest.php
@@ -36,7 +36,9 @@ final class TemplateTest extends UnitTestCase
     #[Test]
     public function createWithInvalidConditionalValue(): void
     {
-        $parameter = Parameter::named('foo')->withConditionalValue(new ConditionalValue('non_existing_condition', 'false'));
+        $parameter = Parameter::named('foo')
+            ->withConditionalValue(ConditionalValue::basedOn('non_existing_condition'))
+        ;
 
         $this->expectException(InvalidArgumentException::class);
         Template::new()->withParameter($parameter);
@@ -77,7 +79,7 @@ final class TemplateTest extends UnitTestCase
         ;
 
         $germanWelcomeMessage = ConditionalValue::basedOn($german)->withValue('Willkommen!');
-        $frenchWelcomeMessage = new ConditionalValue('lang_french', 'Bienvenu!');
+        $frenchWelcomeMessage = ConditionalValue::basedOn($french)->withValue('Bienvenu!');
 
         $welcomeMessageParameter = Parameter::named('welcome_message')
             ->withDefaultValue('Welcome!')


### PR DESCRIPTION
Closes #795 

See https://firebase.google.com/docs/reference/remote-config/rest/v1/RemoteConfig#ParameterValueType

### How to test

In your project using the SDK:

```shell
composer require --with-all-dependencies "kreait/firebase-php:dev-parameter-value-types"
```

Add value types to parameters with

```php
use Kreait\Firebase\RemoteConfig\Parameter;
use Kreait\Firebase\RemoteConfig\ParameterValueType;

$parameter = Parameter::named('test')
    ->withDefaultValue('1')
    ->withValueType(ParameterValueType::NUMBER);
```

The enum with supported Enums can be found at https://github.com/kreait/firebase-php/blob/parameter-value-types/src/Firebase/RemoteConfig/ParameterValueType.php

