### PR TITLE
Use same Client Config for the used `CachedKeySet` as in the other components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* The cached KeySet used by the AppCheck component didn't use the same Guzzle Config Options as the other clients
+  ([#812](https://github.com/kreait/firebase-php/issues/812))
+
 ## [7.5.0] - 2023-06-27
 
 ### Changed

--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -329,7 +329,7 @@ final class Factory
 
         $keySet = new CachedKeySet(
             'https://firebaseappcheck.googleapis.com/v1/jwks',
-            new Client(),
+            new Client($this->httpClientOptions->guzzleConfig()),
             $this->httpFactory,
             $this->keySetCache,
             21600,


### PR DESCRIPTION
Fixes #812