### PR TITLE
Add getter token in NotFound Exception

### DIFF
--- a/src/Firebase/Exception/Messaging/NotFound.php
+++ b/src/Firebase/Exception/Messaging/NotFound.php
@@ -12,15 +12,13 @@ final class NotFound extends RuntimeException implements MessagingException
 {
     use HasErrors;
 
-    private string $token;
+    private ?string $token = null;
 
     /**
      * @param array<mixed> $errors
      */
     public static function becauseTokenNotFound(string $token, array $errors = []): self
     {
-        $this->token = $token;
-        
         $message = <<<MESSAGE
 
 
@@ -43,6 +41,7 @@ final class NotFound extends RuntimeException implements MessagingException
 
         $notFound = new self($message);
         $notFound->errors = $errors;
+        $notFound->token = $token;
 
         return $notFound;
     }
@@ -60,7 +59,7 @@ final class NotFound extends RuntimeException implements MessagingException
         return $new;
     }
 
-    public function token(): string
+    public function token(): ?string
     {
         return $this->token;
     }

--- a/src/Firebase/Exception/Messaging/NotFound.php
+++ b/src/Firebase/Exception/Messaging/NotFound.php
@@ -60,7 +60,7 @@ final class NotFound extends RuntimeException implements MessagingException
         return $new;
     }
 
-    public function getToken(): string
+    public function token(): string
     {
         return $this->token;
     }

--- a/src/Firebase/Exception/Messaging/NotFound.php
+++ b/src/Firebase/Exception/Messaging/NotFound.php
@@ -12,11 +12,15 @@ final class NotFound extends RuntimeException implements MessagingException
 {
     use HasErrors;
 
+    private string $token;
+
     /**
      * @param array<mixed> $errors
      */
     public static function becauseTokenNotFound(string $token, array $errors = []): self
     {
+        $this->token = $token;
+        
         $message = <<<MESSAGE
 
 
@@ -54,5 +58,10 @@ final class NotFound extends RuntimeException implements MessagingException
         $new->errors = $errors;
 
         return $new;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
     }
 }

--- a/tests/Integration/MessagingTest.php
+++ b/tests/Integration/MessagingTest.php
@@ -382,6 +382,20 @@ final class MessagingTest extends IntegrationTestCase
     }
 
     #[Test]
+    public function getTokenFromNotFoundException(): void
+    {
+        $this->expectException(NotFound::class);
+
+        try {
+            $this->messaging->send(['token' => self::$unknownToken]);
+        } catch (NotFound $e) {
+            $this->assertSame(self::$unknownToken, $e->token());
+
+            throw $e;
+        }
+    }
+
+    #[Test]
     public function getAppInstanceForUnknownToken(): void
     {
         $this->expectException(NotFound::class);


### PR DESCRIPTION
Use case:
When using the firebase messaging service, we store the device token to send the the push notifications. sometimes we ended with unregistered token from the firebase project. the api throw an error and is catch by `NotFound` exception.
As backend service is no need to use that token that was unregistered. it will be good to know which `token` that was throw in the exception because the user it may have multiple device token stored in the backend.