### PR TITLE
Move google/cloud-firestore from require-dev to require in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "firebase/php-jwt": "^6.3.2",
         "google/auth": "^1.24",
         "google/cloud-core": "^1.48.1",
+        "google/cloud-firestore": "^1.37.0",
         "google/cloud-storage": "^1.30.1",
         "guzzlehttp/guzzle": "^7.5",
         "kreait/firebase-tokens": "^4.2",
@@ -45,7 +46,6 @@
     "require-dev": {
         "beste/php-cs-fixer-config": "^2.3",
         "friendsofphp/php-cs-fixer": "^3.25.1",
-        "google/cloud-firestore": "^1.37.0",
         "phpstan/extension-installer": "^1.3.1",
         "phpstan/phpstan": "^1.10.33",
         "phpstan/phpstan-phpunit": "^1.3.14",


### PR DESCRIPTION
## Problem
While trying to interact with the database using the facade, I encountered the `Kreait\Firebase\Exception\RuntimeException` error, indicating the `Google\Cloud\Firestore\FirestoreClient` class was not found.

## Cause
Upon investigation, I found that the `google/cloud-firestore` package was listed under `require-dev` in the `composer.json` file. This means it's not being installed in production environments, leading to the above error.

## Solution
I've moved the `google/cloud-firestore` package from `require-dev` to `require` in the `composer.json` file to ensure it's installed in all necessary environments.

## Changes
- Moved `google/cloud-firestore` to the `require` section of `composer.json`.

## Testing
I've tested the changes locally by interacting with the database using the facade, and the error no longer appears. I also ran all existing tests to ensure no regressions.
