### PR TITLE
Docs - Cloud Messaging - Error handling example minor typo fixes

### DIFF
--- a/docs/cloud-messaging.rst
+++ b/docs/cloud-messaging.rst
@@ -877,10 +877,10 @@ Error handling example
 
     try {
         $messaging->send($message);
-    catch (MessagingErrors\NotFound $e) {
-        echo 'The target device could not be found: ';
+    } catch (MessagingErrors\NotFound $e) {
+        echo 'The target device could not be found.';
     } catch (MessagingErrors\InvalidMessage $e) {
-        echo 'The given message is malformatted.'
+        echo 'The given message is malformatted.';
     } catch (MessagingErrors\ServerUnavailable $e) {
         $retryAfter = $e->retryAfter();
 
@@ -893,7 +893,7 @@ Error handling example
 
         $messaging->send($message);
     } catch (MessagingErrors\ServerError $e) {
-        echo 'The FCM servers are down.'
+        echo 'The FCM servers are down.';
     } catch (MessagingException $e) {
         // Fallback handling
         echo 'Unable to send message: '.$e->getMessage();


### PR DESCRIPTION
There were few minor typo's in the error handling example. 
- Missing `}` for the try clause
- couple of missing `;`