### PR TITLE
Fix code typo in example

### DIFF
--- a/docs/cloud-messaging.rst
+++ b/docs/cloud-messaging.rst
@@ -433,7 +433,7 @@ You can find the full FCM Options configuration reference in the official docume
         ->withAnalyticsLabel('my-analytics-label');
     // or
     $fcmOptions = [
-        'analytics_label' => 'my-analytics-label';
+        'analytics_label' => 'my-analytics-label'
     ];
 
     $message = $message->withFcmOptions($fcmOptions);


### PR DESCRIPTION
Remove an extra semicolon from the code example in the documentation.