### PR TITLE
Allow psr/http-message v1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "psr/clock": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "psr/log": "^1.1|^2.0|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi,

Look like during the release of [7.7.0](https://github.com/kreait/firebase-php/compare/7.6.0...7.7.0), support for `psr/http-message` v1.0 was dropped accidently, while v1.0 can still be supported.

It would be helpful to bring back the support for `psr/http-message` v1.0 because many of legacy php packages depends on v1.x .

Thanks.