### PR TITLE
Add versionNumber to RemoteConfig getTemplate

### DIFF
--- a/docs/remote-config.rst
+++ b/docs/remote-config.rst
@@ -60,6 +60,7 @@ Get the Remote Config
 
     $template = $remoteConfig->get(); // Returns a Kreait\Firebase\RemoteConfig\Template
     $version = $template->version(); // Returns a Kreait\Firebase\RemoteConfig\Version
+    $template = $remoteConfig->get($version->versionNumber()); // Returns a Kreait\Firebase\RemoteConfig\Template with the specified version
 
 **************************
 Create a new Remote Config

--- a/src/Firebase/Contract/RemoteConfig.php
+++ b/src/Firebase/Contract/RemoteConfig.php
@@ -25,9 +25,11 @@ use Traversable;
 interface RemoteConfig
 {
     /**
+     * @param VersionNumber|positive-int|non-empty-string|null $versionNumber
+     *
      * @throws RemoteConfigException if something went wrong
      */
-    public function get(): Template;
+    public function get(VersionNumber|int|string $versionNumber = null): Template;
 
     /**
      * Validates the given template without publishing it.

--- a/src/Firebase/RemoteConfig.php
+++ b/src/Firebase/RemoteConfig.php
@@ -28,9 +28,13 @@ final class RemoteConfig implements Contract\RemoteConfig
     {
     }
 
-    public function get(): Template
+    public function get(VersionNumber|int|string $versionNumber = null): Template
     {
-        return $this->buildTemplateFromResponse($this->client->getTemplate());
+        if ($versionNumber !== null) {
+            $versionNumber = $this->ensureVersionNumber($versionNumber);
+        }
+
+        return $this->buildTemplateFromResponse($this->client->getTemplate($versionNumber));
     }
 
     public function validate($template): void

--- a/src/Firebase/RemoteConfig/ApiClient.php
+++ b/src/Firebase/RemoteConfig/ApiClient.php
@@ -29,11 +29,17 @@ class ApiClient
     }
 
     /**
+     * @see https://firebase.google.com/docs/reference/remote-config/rest/v1/projects/getRemoteConfig
+     *
      * @throws RemoteConfigException
      */
-    public function getTemplate(): ResponseInterface
+    public function getTemplate(VersionNumber|int|string $versionNumber = null): ResponseInterface
     {
-        return $this->requestApi('GET', 'remoteConfig');
+        return $this->requestApi('GET', 'remoteConfig', [
+            'query' => array_filter([
+                'version_number' => (string) $versionNumber,
+            ]),
+        ]);
     }
 
     /**


### PR DESCRIPTION
I want to fetch an older RemoteConfig version in my project, so I implemented the query parameter.

(The related Firebase API documentation is here: <https://firebase.google.com/docs/reference/remote-config/rest/v1/projects/getRemoteConfig>)