### PR TITLE
Messaging: Add check if HTTP/2 is supported

### DIFF
--- a/src/Firebase/Messaging/ApiClient.php
+++ b/src/Firebase/Messaging/ApiClient.php
@@ -43,12 +43,19 @@ class ApiClient
 
         $body = $this->streamFactory->createStream(Json::encode($payload));
 
-        return $request
-            ->withProtocolVersion('2.0')
+        $request = $request
             ->withBody($body)
             ->withHeader('Content-Type', 'application/json; charset=UTF-8')
             ->withHeader('Content-Length', (string) $body->getSize())
         ;
+
+        // @codeCoverageIgnoreStart
+        if (defined('CURL_HTTP_VERSION_2') || defined('CURL_HTTP_VERSION_2_0')) {
+            $request = $request->withProtocolVersion('2.0');
+        }
+        // @codeCoverageIgnoreEnd
+
+        return $request;
     }
 
     /**


### PR DESCRIPTION
Fixes #888, https://github.com/kreait/laravel-firebase/issues/219

As reported in the issues above, environments that don't have at least cURL 7.47 (released in 2016) installed, seem unable to send FCM Messages since Release 7.10.0 of the SDK.

This PR tries to address this.

:octocat: 