### PR TITLE
Allow replacing the guzzle handler

### DIFF
--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -22,6 +22,7 @@ use Google\Cloud\Storage\StorageClient;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\MessageFormatter;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Utils as GuzzleUtils;
 use Kreait\Firebase\AppCheck\AppCheckTokenGenerator;
@@ -41,6 +42,7 @@ use Kreait\Firebase\Messaging\AppInstanceApiClient;
 use Kreait\Firebase\Messaging\RequestFactory;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Clock\ClockInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -540,7 +542,7 @@ final class Factory
 
         $config = [...$this->httpClientOptions->guzzleConfig(), ...$config];
 
-        $handler = HandlerStack::create();
+        $handler = HandlerStack::create($this->httpClientOptions->guzzleHandler());
 
         if ($this->httpLogMiddleware) {
             $handler->push($this->httpLogMiddleware, 'http_logs');

--- a/src/Firebase/Http/HttpClientOptions.php
+++ b/src/Firebase/Http/HttpClientOptions.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\Http;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\RequestOptions;
 use Kreait\Firebase\Exception\InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
 
 use function is_callable;
 
 final class HttpClientOptions
 {
+    /** @var callable(RequestInterface, array): PromiseInterface|null */
+    private $guzzleHandler = null;
+
     /**
      * @param array<non-empty-string, mixed> $guzzleConfig
      * @param list<array{middleware: callable, name: string}> $guzzleMiddlewares
@@ -189,5 +194,24 @@ final class HttpClientOptions
         }
 
         return new self($this->guzzleConfig, $newMiddlewares);
+    }
+
+    /**
+     * The guzzle Handler to be used in Guzzles HandlerStack.
+     *
+     * @return callable(RequestInterface, array): PromiseInterface|null
+     */
+    public function guzzleHandler(): callable|null
+    {
+        return $this->guzzleHandler;
+    }
+
+    /**
+     * @param callable(RequestInterface, array): PromiseInterface $value the guzzle Handler to be used in Guzzles HandlerStack
+     */
+    public function withGuzzleHandler(callable $handler): self
+    {
+        $this->guzzleHandler = $handler;
+        return $this;
     }
 }


### PR DESCRIPTION
This allows setting e.g. `Amp\Http\Client\GuzzleAdapter\GuzzleHandlerAdapter`, allowing the whole firebase-php environment to transparently run asynchronously.

Up to now this required very ugly hacking manipulating private fields directly, like:
```
(fn() => (fn() => (fn() => (fn() => $this->handler = new GuzzleHandlerAdapter)->call($this->config["handler"]))->call($this->client))->call($this->messagingApi))->call($messaging);
```

Which is not exactly ergonomic.