### PR TITLE
Composer Dependency Analyser: update to analyse `ext-*`

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -10,4 +10,5 @@ return (new Configuration())
     ->addPathToScan(__DIR__.'/src', false)
     ->addPathToScan(__DIR__.'/tests', true)
     ->ignoreErrorsOnPackage('google/cloud-firestore', [ErrorType::DEV_DEPENDENCY_IN_PROD])
+    ->ignoreErrorsOnExtensionAndPath('ext-curl', 'src/Firebase/Messaging/RequestFactory.php', [ErrorType::SHADOW_DEPENDENCY]) // guarded with extension_loaded
 ;

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "ext-filter": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "ext-openssl": "*",
         "beste/clock": "^3.0",
         "beste/in-memory-cache": "^1.0",
         "beste/json": "^1.2.1",
@@ -58,7 +57,7 @@
         "phpstan/phpstan-phpunit": "^1.4.0",
         "phpunit/phpunit": "^10.5.38",
         "rector/rector": "^1.2.10",
-        "shipmonk/composer-dependency-analyser": "^1.7.0",
+        "shipmonk/composer-dependency-analyser": "^1.8.1",
         "symfony/var-dumper": "^6.4.14 || ^7.0.7",
         "vlucas/phpdotenv": "^5.6.1"
     },


### PR DESCRIPTION
- Updates analyser to [latest version](https://github.com/shipmonk-rnd/composer-dependency-analyser/releases/tag/1.8.0) that checks even `ext-*` dependencies
- **Removes** reported dead dependency on `ext-openssl` (which seems valid)