### PR TITLE
feat: Add accept header to HTTP requests

### DIFF
--- a/src/Firebase/Messaging/RequestFactory.php
+++ b/src/Firebase/Messaging/RequestFactory.php
@@ -48,6 +48,7 @@ final class RequestFactory
             ->withBody($body)
             ->withHeader('Content-Type', 'application/json; charset=UTF-8')
             ->withHeader('Content-Length', (string) $body->getSize())
+            ->withHeader('Accept', 'application/json, text/plain;q=0.9')
         ;
     }
 


### PR DESCRIPTION
Recently we had a POST to https://fcm.googleapis.com that failed (a 502). The response was more noisy than necessary because it was HTML. Ideally the response could be a simple JSON or plain text instead.

I am not sure if the Google API will respect the Accept header in this scenario, my experience with firebase is admittedly fairly limited, but it I don't think it hurts adding it?