### PR TITLE
Update SetApnsContentAvailableIfNeeded.php

### DIFF
--- a/src/Firebase/Messaging/Processor/SetApnsContentAvailableIfNeeded.php
+++ b/src/Firebase/Messaging/Processor/SetApnsContentAvailableIfNeeded.php
@@ -43,7 +43,7 @@ final class SetApnsContentAvailableIfNeeded
             return $message;
         }
 
-        $apnsConfig = $apnsConfig->withApsField('content-available', 1);
+        $apnsConfig = $apnsConfig->withApsField('content-available', '1');
 
         $payload['apns'] = $apnsConfig->toArray();
 


### PR DESCRIPTION
- data array only supports strings
- our fcm 'data' only message fails to deliver because 1 is not string

please see https://github.com/laravel-notification-channels/fcm/issues/220