### PR TITLE
Add conditionable trait to be used in classes

### DIFF
--- a/src/Firebase/Concerns/Conditionable.php
+++ b/src/Firebase/Concerns/Conditionable.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kreait\Firebase\Concerns;
+
+trait Conditionable
+{
+    /**
+     * Conditionally apply a callback if the given condition is true.
+     *
+     * @param bool $condition The condition to evaluate.
+     * @param callable $callback The callback to execute if condition is true.
+     * @param callable|null $default The fallback callback if condition is false.
+     * @return $this|mixed
+     */
+    public function when(
+        bool $condition,
+        callable $callback,
+        ?callable $default = null,
+    ): mixed {
+        if ($condition) {
+            return $callback($this);
+        }
+
+        if ($default !== null) {
+            return $default($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Conditionally apply a callback if the given condition is false.
+     *
+     * @param bool $condition The condition to evaluate.
+     * @param callable $callback The callback to execute if condition is false.
+     * @param callable|null $default The fallback callback if condition is true.
+     * @return $this|mixed
+     */
+    public function unless(
+        bool $condition,
+        callable $callback,
+        ?callable $default = null,
+    ): mixed {
+        return $this->when(! $condition, $callback, $default);
+    }
+}

--- a/src/Firebase/Messaging/AndroidConfig.php
+++ b/src/Firebase/Messaging/AndroidConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Messaging;
 
 use JsonSerializable;
+use Kreait\Firebase\Concerns\Conditionable;
 use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 
 use function array_filter;
@@ -81,6 +82,8 @@ use function sprintf;
  */
 final class AndroidConfig implements JsonSerializable
 {
+    use Conditionable;
+
     private const MESSAGE_PRIORITY_NORMAL = 'normal';
 
     private const MESSAGE_PRIORITY_HIGH = 'high';

--- a/src/Firebase/Messaging/ApnsConfig.php
+++ b/src/Firebase/Messaging/ApnsConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Messaging;
 
 use JsonSerializable;
+use Kreait\Firebase\Concerns\Conditionable;
 use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 
 use function array_filter;
@@ -27,6 +28,8 @@ use function array_key_exists;
  */
 final class ApnsConfig implements JsonSerializable
 {
+    use Conditionable;
+
     private const PRIORITY_CONSERVE_POWER = '5';
 
     private const PRIORITY_IMMEDIATE = '10';

--- a/src/Firebase/Messaging/CloudMessage.php
+++ b/src/Firebase/Messaging/CloudMessage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Messaging;
 
 use Beste\Json;
+use Kreait\Firebase\Concerns\Conditionable;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Exception\Messaging\InvalidArgument;
 use Stringable;
@@ -28,6 +29,8 @@ use function implode;
  */
 final class CloudMessage implements Message
 {
+    use Conditionable;
+
     private MessageData $data;
 
     private Notification $notification;

--- a/tests/Unit/Messaging/AndroidConfigTest.php
+++ b/tests/Unit/Messaging/AndroidConfigTest.php
@@ -84,6 +84,54 @@ final class AndroidConfigTest extends UnitTestCase
         ]);
     }
 
+    #[Test]
+    public function itDoesApplyConditionableWhenConditionIsTrue(): void
+    {
+        $config = AndroidConfig::new()
+            ->when(true, fn(AndroidConfig $config): AndroidConfig => $config->withDefaultSound());
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['notification' => ['sound' => 'default']]),
+            Json::encode($config),
+        );
+
+        $config = AndroidConfig::new()
+            ->unless(false, fn(AndroidConfig $config): AndroidConfig => $config->withDefaultSound());
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['notification' => ['sound' => 'default']]),
+            Json::encode($config),
+        );
+
+        $config = AndroidConfig::new()
+            ->when(true === false, fn(AndroidConfig $config): AndroidConfig => $config->withDefaultSound(), fn(AndroidConfig $config): AndroidConfig => $config->withHighMessagePriority());
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['priority' => 'high']),
+            Json::encode($config),
+        );
+    }
+
+    #[Test]
+    public function itDoesNotApplyConditionableWhenConditionIsFalse(): void
+    {
+        $config = AndroidConfig::new()
+            ->when(false, fn(AndroidConfig $config): AndroidConfig => $config->withDefaultSound());
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode([]),
+            Json::encode($config),
+        );
+
+        $config = AndroidConfig::new()
+            ->unless(true, fn(AndroidConfig $config): AndroidConfig => $config->withDefaultSound());
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode([]),
+            Json::encode($config),
+        );
+    }
+
     public static function validDataProvider(): Iterator
     {
         yield 'full_config' => [[

--- a/tests/Unit/Messaging/ApnsConfigTest.php
+++ b/tests/Unit/Messaging/ApnsConfigTest.php
@@ -125,6 +125,54 @@ final class ApnsConfigTest extends UnitTestCase
         );
     }
 
+    #[Test]
+    public function itDoesApplyConditionableWhenConditionIsTrue(): void
+    {
+        $config = ApnsConfig::new()
+            ->when(true, static fn(ApnsConfig $config): ApnsConfig => $config->withBadge(42));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['payload' => ['aps' => ['badge' => 42]]]),
+            Json::encode($config),
+        );
+
+        $config = ApnsConfig::new()
+            ->unless(false, static fn(ApnsConfig $config): ApnsConfig => $config->withBadge(42));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['payload' => ['aps' => ['badge' => 42]]]),
+            Json::encode($config),
+        );
+
+        $config = ApnsConfig::new()
+            ->when(true === false, static fn(ApnsConfig $config): ApnsConfig => $config->withBadge(42), fn(ApnsConfig $config): ApnsConfig => $config->withBadge(32));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['payload' => ['aps' => ['badge' => 32]]]),
+            Json::encode($config),
+        );
+    }
+
+    #[Test]
+    public function itDoesNotApplyConditionableWhenConditionIsFalse(): void
+    {
+        $config = ApnsConfig::new()
+            ->when(false, static fn(ApnsConfig $config): ApnsConfig => $config->withBadge(42));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode([]),
+            Json::encode($config),
+        );
+
+        $config = ApnsConfig::new()
+            ->unless(true, static fn(ApnsConfig $config): ApnsConfig => $config->withBadge(42));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode([]),
+            Json::encode($config),
+        );
+    }
+
     public static function validDataProvider(): Iterator
     {
         yield 'full_config' => [[

--- a/tests/Unit/Messaging/CloudMessageTest.php
+++ b/tests/Unit/Messaging/CloudMessageTest.php
@@ -148,6 +148,56 @@ final class CloudMessageTest extends TestCase
         $this->assertSame($serializedFromObject, $serializedFromArray);
     }
 
+    #[Test]
+    public function itDoesApplyConditionableWhenConditionIsTrue(): void
+    {
+        $data = ['key' => 'value'];
+
+        $message = CloudMessage::new()
+            ->when(true, fn(CloudMessage $message): CloudMessage => $message->withData(MessageData::fromArray($data)));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['data' => $data]),
+            Json::encode($message),
+        );
+
+        $message = CloudMessage::new()
+            ->unless(false, fn(CloudMessage $message): CloudMessage => $message->withData(MessageData::fromArray($data)));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['data' => $data]),
+            Json::encode($message),
+        );
+
+        $message = CloudMessage::new()
+            ->when(true === false, fn(CloudMessage $message): CloudMessage => $message->withData(MessageData::fromArray($data)), fn(CloudMessage $message): CloudMessage => $message->withData(MessageData::fromArray(['key' => 'other'])));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode(['data' => ['key' => 'other']]),
+            Json::encode($message),
+        );
+    }
+
+    #[Test]
+    public function itDoesNotApplyConditionableWhenConditionIsFalse(): void
+    {
+        $message = CloudMessage::new()
+            ->when(false, fn(CloudMessage $message): CloudMessage => $message->withData(MessageData::fromArray(['key' => 'value'])));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode([]),
+            Json::encode($message),
+        );
+
+        $message = CloudMessage::new()
+            ->unless(true, fn(CloudMessage $message): CloudMessage => $message->withData(MessageData::fromArray(['key' => 'value'])));
+
+        $this->assertJsonStringEqualsJsonString(
+            Json::encode([]),
+            Json::encode($message),
+        );
+    }
+
     public static function multipleTargets(): Iterator
     {
         yield 'condition and token' => [[


### PR DESCRIPTION
## What does it do
Add a conditionable trait to be able to do the following.

```php
$config = ApnsConfig::new()
    ->when($deeplink !== null, fn(ApnsConfig $config) => $config->withApsField('custom_data', ['deeplink' => $deeplink]));

$message = CloudMessage::new()
    ->when($deeplink !== null, fn (CloudMessage $message) => $message->withData(['deeplink' => $deeplink]));
```

I know that this was already achievable with an if statement like this

```php
$message = CloudMessage::new();

if ($deeplink !== null) {
    $message = $message->withData(['deeplink' => $deeplink']);
}
```

So this PR is only if you feel like this would benefit the project.

## What has changed
Currently I have only added this to the `CloudMessage`, `ApnsConfig` and `AndroidConfig` classes and created tests for these classes.