### PR TITLE
Remove the `keyFile` option from the Google Cloud config array

### DIFF
--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -638,11 +638,6 @@ final class Factory
             $config['credentialsFetcher'] = $credentials;
         }
 
-        $serviceAccount = $this->getServiceAccount();
-        if ($serviceAccount !== null) {
-            $config['keyFile'] = $this->normalizeServiceAccount($serviceAccount);
-        }
-
         return $config;
     }
 

--- a/src/Firebase/Factory.php
+++ b/src/Firebase/Factory.php
@@ -524,7 +524,7 @@ final class Factory
     public function createStorage(): Contract\Storage
     {
         try {
-            $storageClient = new StorageClient($this->googleCloudClientConfig());
+            $storageClient = new StorageClient($this->googleCloudClientConfig()); // @phpstan-ignore method.deprecated
         } catch (Throwable $e) {
             throw new RuntimeException('Unable to create a StorageClient: '.$e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Firebase/Firestore.php
+++ b/src/Firebase/Firestore.php
@@ -23,7 +23,7 @@ final class Firestore implements Contract\Firestore
     public static function fromConfig(array $config): Contract\Firestore
     {
         try {
-            return new self(new FirestoreClient($config));
+            return new self(new FirestoreClient($config)); // @phpstan-ignore method.deprecated
         } catch (Throwable $e) {
             throw new RuntimeException('Unable to create a FirestoreClient: '.$e->getMessage(), $e->getCode(), $e);
         }


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-php/pull/8617 marked `keyFile` and `keyFilePath` as deprecated.

:octocat: 