### PR TITLE
Fix Valinor converter signature to match new rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "beste/clock": "^3.0",
         "beste/in-memory-cache": "^1.3.1",
         "beste/json": "^1.5.1",
-        "cuyz/valinor": "^2.0",
+        "cuyz/valinor": "^2.2.1",
         "fig/http-message-util": "^1.1.5",
         "firebase/php-jwt": "^6.10.2",
         "google/auth": "^v1.45",

--- a/src/Firebase/Valinor/Converter/SnakeCaseToCamelCaseConverter.php
+++ b/src/Firebase/Valinor/Converter/SnakeCaseToCamelCaseConverter.php
@@ -13,6 +13,12 @@ use Traversable;
  */
 final class SnakeCaseToCamelCaseConverter
 {
+    /**
+     * @template T of object
+     * @param array<mixed> $value
+     * @param callable(array<mixed>): T $next
+     * @return T
+     */
     public function __invoke(mixed $values, callable $next): object
     {
         if ($values instanceof Traversable) {


### PR DESCRIPTION
Reference: https://github.com/CuyZ/Valinor/releases/tag/2.2.1

Hi @jeromegamez, I'm submitting this just after the [`cuyz/valinor` 2.2.1 release](https://github.com/CuyZ/Valinor/releases/tag/2.2.1) which brings a bugfix that can lead to issues for your library users. As this represents a lot of people, I urged myself to write the fix before people come to complain about it.

I'm sorry about this, that's the first time I'm kind of forced to do a BC break inside a non-major, although I believe it makes sense (as explained in the release notes linked above). I recommend releasing a new version of `kreait/firebase-php` ASAP with this commit.

Note that this commit also marks `cuyz/valinor` versions before 2.2.1 as conflicting. This should prevent a lot of applications having issues that upgrade either this package or `cuyz/valinor` without upgrading the other one.