### PR TITLE
Remove #[SensitiveParameter] attributes for PHP 8.1 support

### DIFF
--- a/src/Firebase/AppCheck/AppCheckTokenGenerator.php
+++ b/src/Firebase/AppCheck/AppCheckTokenGenerator.php
@@ -11,6 +11,8 @@ use Psr\Clock\ClockInterface;
 
 /**
  * @internal
+ *
+ * @todo Add #[SensitiveParameter] attribute to the private key once the minimum required PHP version is >=8.2
  */
 final class AppCheckTokenGenerator
 {
@@ -24,7 +26,6 @@ final class AppCheckTokenGenerator
      */
     public function __construct(
         private readonly string $clientEmail,
-        #[\SensitiveParameter]
         private readonly string $privateKey,
         ?ClockInterface $clock = null,
     ) {

--- a/src/Firebase/ServiceAccount.php
+++ b/src/Firebase/ServiceAccount.php
@@ -6,6 +6,8 @@ namespace Kreait\Firebase;
 
 /**
  * @internal
+ *
+ * @todo Add #[SensitiveParameter] attributes once the minimum required PHP version is >=8.2
  */
 final class ServiceAccount
 {
@@ -13,37 +15,26 @@ final class ServiceAccount
         /** @var non-empty-string */
         public string $type,
         /** @var non-empty-string */
-        #[\SensitiveParameter]
         public string $projectId,
         /** @var non-empty-string */
-        #[\SensitiveParameter]
         public string $clientEmail,
         /** @var non-empty-string */
-        #[\SensitiveParameter]
         public string $privateKey,
         /** @var non-empty-string|null */
-        #[\SensitiveParameter]
         public ?string $clientId = null,
         /** @var non-empty-string|null */
-        #[\SensitiveParameter]
         public ?string $privateKeyId = null,
         /** @var non-empty-string|null */
-        #[\SensitiveParameter]
         public ?string $authUri = null,
         /** @var non-empty-string|null */
-        #[\SensitiveParameter]
         public ?string $tokenUri = null,
         /** @var non-empty-string|null */
-        #[\SensitiveParameter]
         public ?string $authProviderX509CertUrl = null,
         /** @var non-empty-string|null */
-        #[\SensitiveParameter]
         public ?string $clientX509CertUrl = null,
         /** @var non-empty-string|null */
-        #[\SensitiveParameter]
         public ?string $quotaProjectId = null,
         /** @var non-empty-string|null */
-        #[\SensitiveParameter]
         public ?string $universeDomain = null,
     ) {
     }


### PR DESCRIPTION
In this PR, I've reverted commit that adds `SensitiveParameter` attribute to properties because we cannot use it with PHP 8.1. Despite the fact that PHP itself works correctly with this attributes, the issue arises when using reflection, which is used in the `cuyz/valinor` package.

To prove that we could run integration tests with PHP 8.1 and receive errors like that

<details><summary>Error example</summary>
<p>
1) Kreait\Firebase\Tests\Integration\AppCheckTest
ReflectionException: Class "SensitiveParameter" does not exist

/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Utility/Reflection/Reflection.php:60
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Definition/Repository/Reflection/ReflectionAttributesRepository.php:82
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Definition/Repository/Reflection/ReflectionAttributesRepository.php:40
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php:51
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php:143
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php:91
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Definition/Repository/Cache/InMemoryClassDefinitionRepository.php:23
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Mapper/Tree/Builder/ValueConverterNodeBuilder.php:44
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Mapper/Tree/Shell.php:73
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Mapper/Tree/RootNodeBuilder.php:46
/Users/ns/Documents/Playground/firebase-php/vendor/cuyz/valinor/src/Mapper/TypeTreeMapper.php:32
/Users/ns/Documents/Playground/firebase-php/src/Firebase/Valinor/Mapper.php:58
/Users/ns/Documents/Playground/firebase-php/src/Firebase/Factory.php:762
/Users/ns/Documents/Playground/firebase-php/src/Firebase/Factory.php:159
/Users/ns/Documents/Playground/firebase-php/tests/IntegrationTestCase.php:56
</p>
</details> 

I've changed the integration test workflow so that they run on all PHP versions, but I'm not sure whether it was originally set up that way for a specific reason. So we can revert to running them on a single version if needed.