### PR TITLE
Replace `Stringable|string` argument types with `string`-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If it saves you or your team time, please consider [sponsoring its development](
 * [Firebase Dynamic Links was shut down on August 25th, 2025](https://firebase.google.com/support/dynamic-links-faq)
   and has been removed from the SDK.
 * Deprecated classes, methods and class constants have been removed.
+* Replaced `Stringable|string` argument types with `string`-only
 
 See **[UPGRADE-8.0](UPGRADE-8.0.md) for more details on the changes between 7.x and 8.0.**
 

--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -12,6 +12,27 @@ from 7.x to 8.0.
 * [Firebase Dynamic Links was shut down on August 25th, 2025](https://firebase.google.com/support/dynamic-links-faq)
   and has been removed from the SDK.
 
+### Replaced `Stringable|string` argument types with `string`-only
+
+Methods that previously accepted `Stringable|string` as argument types now only support `string`.
+
+`Stringable` was added for convenience so that someone could do, for example
+
+```php
+$user = $auth->getUser('uid');
+$auth->updateUser($user, [...]);
+```
+
+While convenient, this adds overhead when processing these arguments. For example, if a method expects a non-empty
+string, the SDK would have to do a `trim((string) $arg)` and check if it's empty. 
+
+With this change, we can rely only on a `@var non-empty-string $arg` docblock annotation.
+
+```php
+$user = $auth->getUser('uid');
+$auth->updateUser($user->uid, [...]);
+```
+
 ## Complete list of breaking changes
 
 The following list has been generated with [roave/backward-compatibility-check](https://github.com/Roave/BackwardCompatibilityCheck).
@@ -20,12 +41,107 @@ The following list has been generated with [roave/backward-compatibility-check](
 [BC] CHANGED: Default parameter value for parameter $code of Kreait\Firebase\Exception\Database\TransactionFailed#__construct() changed from 0 to NULL
 [BC] CHANGED: Default parameter value for parameter $code of Kreait\Firebase\Exception\Database\UnsupportedQuery#__construct() changed from 0 to NULL
 [BC] CHANGED: The number of required arguments for Kreait\Firebase\Exception\Database\UnsupportedQuery#__construct() increased from 1 to 2
+[BC] CHANGED: The parameter $clearTextPassword of Kreait\Firebase\Contract\Auth#signInWithEmailAndPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $clearTextPassword of Kreait\Firebase\Contract\Auth#signInWithEmailAndPassword() changed from Stringable|string to string
+[BC] CHANGED: The parameter $clearTextPassword of Kreait\Firebase\Request\EditUserTrait#withClearTextPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $clearTextPassword of Kreait\Firebase\Request\EditUserTrait#withClearTextPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $clearTextPassword of Kreait\Firebase\Request\EditUserTrait#withClearTextPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $clearTextPassword of Kreait\Firebase\Request\EditUserTrait#withClearTextPassword() changed from Stringable|string to string
 [BC] CHANGED: The parameter $code of Kreait\Firebase\Exception\Database\TransactionFailed#__construct() changed from int to a non-contravariant Throwable|null
 [BC] CHANGED: The parameter $code of Kreait\Firebase\Exception\Database\UnsupportedQuery#__construct() changed from int to a non-contravariant Throwable|null
-[BC] CHANGED: The parameter $uid of Kreait\Firebase\Request\EditUserTrait#withUid() changed from no type to Stringable|string
-[BC] CHANGED: The parameter $uid of Kreait\Firebase\Request\EditUserTrait#withUid() changed from no type to a non-contravariant Stringable|string
-[BC] CHANGED: The parameter $uid of Kreait\Firebase\Request\EditUserTrait#withUid() changed from no type to a non-contravariant Stringable|string
-[BC] CHANGED: The parameter $uid of Kreait\Firebase\Request\EditUserTrait#withUid() changed from no type to a non-contravariant Stringable|string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#createUserWithEmailAndPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#createUserWithEmailAndPassword() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getEmailActionLink() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getEmailActionLink() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getEmailVerificationLink() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getEmailVerificationLink() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getPasswordResetLink() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getPasswordResetLink() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getSignInWithEmailLink() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getSignInWithEmailLink() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getUserByEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#getUserByEmail() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#sendEmailActionLink() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#sendEmailActionLink() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#sendEmailVerificationLink() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#sendEmailVerificationLink() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#sendPasswordResetLink() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#sendPasswordResetLink() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#sendSignInWithEmailLink() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#sendSignInWithEmailLink() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#signInWithEmailAndOobCode() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#signInWithEmailAndOobCode() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#signInWithEmailAndPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Contract\Auth#signInWithEmailAndPassword() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withEmail() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withUnverifiedEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withUnverifiedEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withUnverifiedEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withUnverifiedEmail() changed from Stringable|string to string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withVerifiedEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withVerifiedEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withVerifiedEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $email of Kreait\Firebase\Request\EditUserTrait#withVerifiedEmail() changed from Stringable|string to string
+[BC] CHANGED: The parameter $newEmail of Kreait\Firebase\Contract\Auth#changeUserEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $newEmail of Kreait\Firebase\Contract\Auth#changeUserEmail() changed from Stringable|string to string
+[BC] CHANGED: The parameter $newPassword of Kreait\Firebase\Contract\Auth#changeUserPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $newPassword of Kreait\Firebase\Contract\Auth#changeUserPassword() changed from Stringable|string to string
+[BC] CHANGED: The parameter $newPassword of Kreait\Firebase\Contract\Auth#confirmPasswordReset() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $newPassword of Kreait\Firebase\Contract\Auth#confirmPasswordReset() changed from Stringable|string to string
+[BC] CHANGED: The parameter $password of Kreait\Firebase\Contract\Auth#createUserWithEmailAndPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $password of Kreait\Firebase\Contract\Auth#createUserWithEmailAndPassword() changed from Stringable|string to string
+[BC] CHANGED: The parameter $phoneNumber of Kreait\Firebase\Contract\Auth#getUserByPhoneNumber() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $phoneNumber of Kreait\Firebase\Contract\Auth#getUserByPhoneNumber() changed from Stringable|string to string
+[BC] CHANGED: The parameter $phoneNumber of Kreait\Firebase\Request\EditUserTrait#withPhoneNumber() changed from no type to a non-contravariant string|null
+[BC] CHANGED: The parameter $phoneNumber of Kreait\Firebase\Request\EditUserTrait#withPhoneNumber() changed from no type to a non-contravariant string|null
+[BC] CHANGED: The parameter $phoneNumber of Kreait\Firebase\Request\EditUserTrait#withPhoneNumber() changed from no type to a non-contravariant string|null
+[BC] CHANGED: The parameter $phoneNumber of Kreait\Firebase\Request\EditUserTrait#withPhoneNumber() changed from no type to string|null
+[BC] CHANGED: The parameter $provider of Kreait\Firebase\Contract\Auth#signInWithIdpAccessToken() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $provider of Kreait\Firebase\Contract\Auth#signInWithIdpAccessToken() changed from Stringable|string to string
+[BC] CHANGED: The parameter $provider of Kreait\Firebase\Contract\Auth#signInWithIdpIdToken() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $provider of Kreait\Firebase\Contract\Auth#signInWithIdpIdToken() changed from Stringable|string to string
+[BC] CHANGED: The parameter $provider of Kreait\Firebase\Contract\Auth#unlinkProvider() changed from array|Stringable|string to a non-contravariant array|string
+[BC] CHANGED: The parameter $provider of Kreait\Firebase\Contract\Auth#unlinkProvider() changed from array|Stringable|string to array|string
+[BC] CHANGED: The parameter $provider of Kreait\Firebase\Request\UpdateUser#withRemovedProvider() changed from no type to a non-contravariant string
+[BC] CHANGED: The parameter $providerId of Kreait\Firebase\Contract\Transitional\FederatedUserFetcher#getUserByProviderUid() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $providerId of Kreait\Firebase\Contract\Transitional\FederatedUserFetcher#getUserByProviderUid() changed from Stringable|string to string
+[BC] CHANGED: The parameter $providerUid of Kreait\Firebase\Contract\Transitional\FederatedUserFetcher#getUserByProviderUid() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $providerUid of Kreait\Firebase\Contract\Transitional\FederatedUserFetcher#getUserByProviderUid() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#changeUserEmail() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#changeUserEmail() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#changeUserPassword() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#changeUserPassword() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#createCustomToken() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#createCustomToken() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#deleteUser() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#deleteUser() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#disableUser() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#disableUser() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#enableUser() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#enableUser() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#getUser() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#getUser() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#revokeRefreshTokens() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#revokeRefreshTokens() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#setCustomUserClaims() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#setCustomUserClaims() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#unlinkProvider() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#unlinkProvider() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#updateUser() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Contract\Auth#updateUser() changed from Stringable|string to string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Request\EditUserTrait#withUid() changed from no type to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Request\EditUserTrait#withUid() changed from no type to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Request\EditUserTrait#withUid() changed from no type to a non-contravariant string
+[BC] CHANGED: The parameter $uid of Kreait\Firebase\Request\EditUserTrait#withUid() changed from no type to string
+[BC] CHANGED: The parameter $url of Kreait\Firebase\Request\EditUserTrait#withPhotoUrl() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $url of Kreait\Firebase\Request\EditUserTrait#withPhotoUrl() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $url of Kreait\Firebase\Request\EditUserTrait#withPhotoUrl() changed from Stringable|string to a non-contravariant string
+[BC] CHANGED: The parameter $url of Kreait\Firebase\Request\EditUserTrait#withPhotoUrl() changed from Stringable|string to string
+[BC] CHANGED: The parameter $user of Kreait\Firebase\Contract\Auth#signInAsUser() changed from Kreait\Firebase\Auth\UserRecord|Stringable|string to Kreait\Firebase\Auth\UserRecord|string
+[BC] CHANGED: The parameter $user of Kreait\Firebase\Contract\Auth#signInAsUser() changed from Kreait\Firebase\Auth\UserRecord|Stringable|string to a non-contravariant Kreait\Firebase\Auth\UserRecord|string
 [BC] CHANGED: The return type of Kreait\Firebase\RemoteConfig\ConditionalValue#value() changed from no type to string|array
 [BC] CHANGED: The return type of Kreait\Firebase\RemoteConfig\TagColor#__toString() changed from no type to string
 [BC] REMOVED: Class Kreait\Firebase\Contract\DynamicLinks has been deleted

--- a/src/Firebase/Auth.php
+++ b/src/Firebase/Auth.php
@@ -46,7 +46,6 @@ use Lcobucci\JWT\Token;
 use Lcobucci\JWT\UnencryptedToken;
 use Psr\Clock\ClockInterface;
 use Psr\Http\Message\ResponseInterface;
-use Stringable;
 use Throwable;
 use Traversable;
 
@@ -76,7 +75,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         $this->jwtParser = new Parser(new JoseEncoder());
     }
 
-    public function getUser(Stringable|string $uid): UserRecord
+    public function getUser(string $uid): UserRecord
     {
         $uid = Uid::fromString($uid)->value;
 
@@ -91,7 +90,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
 
     public function getUsers(array $uids): array
     {
-        $uids = array_map(static fn(\Stringable|string $uid): string => Uid::fromString($uid)->value, $uids);
+        $uids = array_map(static fn(string $uid): string => Uid::fromString($uid)->value, $uids);
 
         $users = array_fill_keys($uids, null);
 
@@ -161,7 +160,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         return $this->getUserRecordFromResponseAfterUserUpdate($response);
     }
 
-    public function updateUser(Stringable|string $uid, array|UpdateUser $properties): UserRecord
+    public function updateUser(string $uid, array|UpdateUser $properties): UserRecord
     {
         $request = $properties instanceof UpdateUser
             ? $properties
@@ -174,7 +173,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         return $this->getUserRecordFromResponseAfterUserUpdate($response);
     }
 
-    public function createUserWithEmailAndPassword(Stringable|string $email, Stringable|string $password): UserRecord
+    public function createUserWithEmailAndPassword(string $email, string $password): UserRecord
     {
         return $this->createUser(
             CreateUser::new()
@@ -183,9 +182,9 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         );
     }
 
-    public function getUserByEmail(Stringable|string $email): UserRecord
+    public function getUserByEmail(string $email): UserRecord
     {
-        $email = Email::fromString((string) $email)->value;
+        $email = Email::fromString($email)->value;
 
         $response = $this->client->getUserByEmail($email);
 
@@ -198,10 +197,8 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         return $userRecord;
     }
 
-    public function getUserByPhoneNumber(Stringable|string $phoneNumber): UserRecord
+    public function getUserByPhoneNumber(string $phoneNumber): UserRecord
     {
-        $phoneNumber = (string) $phoneNumber;
-
         $response = $this->client->getUserByPhoneNumber($phoneNumber);
 
         $userRecord = self::getFirstUserRecordFromUserListResponse($response);
@@ -213,11 +210,8 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         return $userRecord;
     }
 
-    public function getUserByProviderUid(Stringable|string $providerId, Stringable|string $providerUid): UserRecord
+    public function getUserByProviderUid(string $providerId, string $providerUid): UserRecord
     {
-        $providerId = (string) $providerId;
-        $providerUid = (string) $providerUid;
-
         $response = $this->client->getUserByProviderUid($providerId, $providerUid);
 
         $userRecord = self::getFirstUserRecordFromUserListResponse($response);
@@ -234,27 +228,27 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         return $this->createUser(CreateUser::new());
     }
 
-    public function changeUserPassword(Stringable|string $uid, Stringable|string $newPassword): UserRecord
+    public function changeUserPassword(string $uid, string $newPassword): UserRecord
     {
         return $this->updateUser($uid, UpdateUser::new()->withClearTextPassword($newPassword));
     }
 
-    public function changeUserEmail(Stringable|string $uid, Stringable|string $newEmail): UserRecord
+    public function changeUserEmail(string $uid, string $newEmail): UserRecord
     {
         return $this->updateUser($uid, UpdateUser::new()->withEmail($newEmail));
     }
 
-    public function enableUser(Stringable|string $uid): UserRecord
+    public function enableUser(string $uid): UserRecord
     {
         return $this->updateUser($uid, UpdateUser::new()->markAsEnabled());
     }
 
-    public function disableUser(Stringable|string $uid): UserRecord
+    public function disableUser(string $uid): UserRecord
     {
         return $this->updateUser($uid, UpdateUser::new()->markAsDisabled());
     }
 
-    public function deleteUser(Stringable|string $uid): void
+    public function deleteUser(string $uid): void
     {
         $uid = Uid::fromString($uid)->value;
 
@@ -277,9 +271,9 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         return DeleteUsersResult::fromRequestAndResponse($request, $response);
     }
 
-    public function getEmailActionLink(string $type, Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): string
+    public function getEmailActionLink(string $type, string $email, $actionCodeSettings = null, ?string $locale = null): string
     {
-        $email = Email::fromString((string) $email)->value;
+        $email = Email::fromString($email)->value;
 
         if ($actionCodeSettings === null) {
             $actionCodeSettings = ValidatedActionCodeSettings::empty();
@@ -292,9 +286,9 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         return $this->client->getEmailActionLink($type, $email, $actionCodeSettings, $locale);
     }
 
-    public function sendEmailActionLink(string $type, Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): void
+    public function sendEmailActionLink(string $type, string $email, $actionCodeSettings = null, ?string $locale = null): void
     {
-        $email = Email::fromString((string) $email)->value;
+        $email = Email::fromString($email)->value;
 
         if ($actionCodeSettings === null) {
             $actionCodeSettings = ValidatedActionCodeSettings::empty();
@@ -330,37 +324,37 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         $this->client->sendEmailActionLink($type, $email, $actionCodeSettings, $locale, $idToken);
     }
 
-    public function getEmailVerificationLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): string
+    public function getEmailVerificationLink(string $email, $actionCodeSettings = null, ?string $locale = null): string
     {
         return $this->getEmailActionLink('VERIFY_EMAIL', $email, $actionCodeSettings, $locale);
     }
 
-    public function sendEmailVerificationLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): void
+    public function sendEmailVerificationLink(string $email, $actionCodeSettings = null, ?string $locale = null): void
     {
         $this->sendEmailActionLink('VERIFY_EMAIL', $email, $actionCodeSettings, $locale);
     }
 
-    public function getPasswordResetLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): string
+    public function getPasswordResetLink(string $email, $actionCodeSettings = null, ?string $locale = null): string
     {
         return $this->getEmailActionLink('PASSWORD_RESET', $email, $actionCodeSettings, $locale);
     }
 
-    public function sendPasswordResetLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): void
+    public function sendPasswordResetLink(string $email, $actionCodeSettings = null, ?string $locale = null): void
     {
         $this->sendEmailActionLink('PASSWORD_RESET', $email, $actionCodeSettings, $locale);
     }
 
-    public function getSignInWithEmailLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): string
+    public function getSignInWithEmailLink(string $email, $actionCodeSettings = null, ?string $locale = null): string
     {
         return $this->getEmailActionLink('EMAIL_SIGNIN', $email, $actionCodeSettings, $locale);
     }
 
-    public function sendSignInWithEmailLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): void
+    public function sendSignInWithEmailLink(string $email, $actionCodeSettings = null, ?string $locale = null): void
     {
         $this->sendEmailActionLink('EMAIL_SIGNIN', $email, $actionCodeSettings, $locale);
     }
 
-    public function setCustomUserClaims(Stringable|string $uid, ?array $claims): void
+    public function setCustomUserClaims(string $uid, ?array $claims): void
     {
         $uid = Uid::fromString($uid)->value;
         $claims ??= [];
@@ -368,7 +362,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         $this->client->setCustomUserClaims($uid, $claims);
     }
 
-    public function createCustomToken(Stringable|string $uid, array $claims = [], $ttl = 3600): UnencryptedToken
+    public function createCustomToken(string $uid, array $claims = [], $ttl = 3600): UnencryptedToken
     {
         if ($this->tokenGenerator === null) {
             throw new AuthError('Custom Token Generation is disabled because the current credentials do not permit it');
@@ -507,7 +501,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
         return $email;
     }
 
-    public function revokeRefreshTokens(Stringable|string $uid): void
+    public function revokeRefreshTokens(string $uid): void
     {
         $uid = Uid::fromString($uid)->value;
 
@@ -518,12 +512,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
     {
         $uid = Uid::fromString($uid)->value;
 
-        $provider = array_values(
-            array_filter(
-                array_map(strval(...), (array) $provider),
-                static fn(string $value): bool => $value !== '',
-            ),
-        );
+        $provider = array_map(strval(...), (array) $provider);
 
         $response = $this->client->unlinkProvider($uid, $provider);
 
@@ -533,7 +522,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
     public function signInAsUser($user, ?array $claims = null): SignInResult
     {
         $claims ??= [];
-        $uid = $user instanceof UserRecord ? $user->uid : (string) $user;
+        $uid = $user instanceof UserRecord ? $user->uid : $user;
 
         try {
             $customToken = $this->createCustomToken($uid, $claims);
@@ -560,7 +549,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
 
     public function signInWithEmailAndPassword($email, $clearTextPassword): SignInResult
     {
-        $email = Email::fromString((string) $email)->value;
+        $email = Email::fromString($email)->value;
         $clearTextPassword = ClearTextPassword::fromString($clearTextPassword)->value;
 
         return $this->client->handleSignIn(SignInWithEmailAndPassword::fromValues($email, $clearTextPassword));
@@ -568,7 +557,7 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
 
     public function signInWithEmailAndOobCode($email, string $oobCode): SignInResult
     {
-        $email = Email::fromString((string) $email)->value;
+        $email = Email::fromString($email)->value;
 
         return $this->client->handleSignIn(SignInWithEmailAndOobCode::fromValues($email, $oobCode));
     }
@@ -591,7 +580,6 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
 
     public function signInWithIdpAccessToken($provider, string $accessToken, $redirectUrl = null, ?string $oauthTokenSecret = null, ?string $linkingIdToken = null, ?string $rawNonce = null): SignInResult
     {
-        $provider = (string) $provider;
         $redirectUrl = trim((string) ($redirectUrl ?? 'http://localhost'));
         $linkingIdToken = trim((string) $linkingIdToken);
         $oauthTokenSecret = trim((string) $oauthTokenSecret);
@@ -620,7 +608,6 @@ final readonly class Auth implements Contract\Auth, FederatedUserFetcher
 
     public function signInWithIdpIdToken($provider, $idToken, $redirectUrl = null, ?string $linkingIdToken = null, ?string $rawNonce = null): SignInResult
     {
-        $provider = trim((string) $provider);
         $redirectUrl = trim((string) ($redirectUrl ?? 'http://localhost'));
         $linkingIdToken = trim((string) $linkingIdToken);
         $rawNonce = trim((string) $rawNonce);

--- a/src/Firebase/Auth/ApiClient.php
+++ b/src/Firebase/Auth/ApiClient.php
@@ -20,7 +20,6 @@ use Kreait\Firebase\Request\CreateUser;
 use Kreait\Firebase\Request\UpdateUser;
 use Psr\Clock\ClockInterface;
 use Psr\Http\Message\ResponseInterface;
-use Stringable;
 use Throwable;
 
 use function array_filter;
@@ -239,7 +238,7 @@ class ApiClient
     }
 
     /**
-     * @param list<Stringable|non-empty-string> $providers
+     * @param list<non-empty-string> $providers
      *
      * @throws AuthException
      */

--- a/src/Firebase/Auth/CreateActionLink.php
+++ b/src/Firebase/Auth/CreateActionLink.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Auth;
 
 use Kreait\Firebase\Value\Email;
-use Stringable;
 
 /**
  * @internal
@@ -21,9 +20,9 @@ final readonly class CreateActionLink
     ) {
     }
 
-    public static function new(string $type, Stringable|string $email, ActionCodeSettings $settings, ?string $tenantId = null, ?string $locale = null): self
+    public static function new(string $type, string $email, ActionCodeSettings $settings, ?string $tenantId = null, ?string $locale = null): self
     {
-        $email = Email::fromString((string) $email)->value;
+        $email = Email::fromString($email)->value;
 
         return new self($tenantId, $locale, $type, $email, $settings);
     }

--- a/src/Firebase/Auth/CustomTokenViaGoogleCredentials.php
+++ b/src/Firebase/Auth/CustomTokenViaGoogleCredentials.php
@@ -13,7 +13,6 @@ use Kreait\Firebase\Util\DT;
 use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Token\Parser;
-use Stringable;
 
 /**
  * @internal
@@ -31,13 +30,15 @@ final readonly class CustomTokenViaGoogleCredentials
     }
 
     /**
-     * @param Stringable|string $uid
+     * @param non-empty-string $uid
      * @param array<non-empty-string, mixed> $claims
      *
      * @throws AuthError
      */
-    public function createCustomToken($uid, array $claims = [], ?DateTimeInterface $expiresAt = null): Token
+    public function createCustomToken(string $uid, ?array $claims = null, ?DateTimeInterface $expiresAt = null): Token
     {
+        $claims ??= [];
+
         $now = new DateTimeImmutable();
         $expiresAt = ($expiresAt !== null)
             ? DT::toUTCDateTimeImmutable($expiresAt)
@@ -50,7 +51,7 @@ final readonly class CustomTokenViaGoogleCredentials
             'aud' => 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit',
             'iat' => $now->getTimestamp(),
             'exp' => $expiresAt->getTimestamp(),
-            'uid' => (string) $uid,
+            'uid' => $uid,
         ];
 
         if ($this->tenantId !== null) {

--- a/src/Firebase/Auth/DeleteUsersRequest.php
+++ b/src/Firebase/Auth/DeleteUsersRequest.php
@@ -6,7 +6,6 @@ namespace Kreait\Firebase\Auth;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Value\Uid;
-use Stringable;
 
 /**
  * @internal
@@ -23,7 +22,7 @@ final readonly class DeleteUsersRequest
     }
 
     /**
-     * @param iterable<Stringable|string> $uids
+     * @param iterable<string> $uids
      */
     public static function withUids(iterable $uids, bool $forceDeleteEnabledUsers = false): self
     {

--- a/src/Firebase/Contract/Auth.php
+++ b/src/Firebase/Contract/Auth.php
@@ -30,7 +30,6 @@ use Kreait\Firebase\Request\UpdateUser;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\UnencryptedToken;
 use Psr\Http\Message\UriInterface;
-use Stringable;
 use Traversable;
 
 /**
@@ -39,16 +38,16 @@ use Traversable;
 interface Auth
 {
     /**
-     * @param Stringable|non-empty-string $uid
+     * @param non-empty-string $uid
      *
      * @throws UserNotFound
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function getUser(Stringable|string $uid): UserRecord;
+    public function getUser(string $uid): UserRecord;
 
     /**
-     * @param non-empty-list<Stringable|non-empty-string> $uids
+     * @param non-empty-list<non-empty-string> $uids
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
@@ -91,38 +90,39 @@ interface Auth
     /**
      * Updates the given user with the given properties.
      *
+     * @param non-empty-string $uid
      * @param non-empty-array<non-empty-string, mixed>|UpdateUser $properties
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function updateUser(Stringable|string $uid, array|UpdateUser $properties): UserRecord;
+    public function updateUser(string $uid, array|UpdateUser $properties): UserRecord;
 
     /**
-     * @param Stringable|non-empty-string $email
-     * @param Stringable|non-empty-string $password
+     * @param non-empty-string $email
+     * @param non-empty-string $password
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function createUserWithEmailAndPassword(Stringable|string $email, Stringable|string $password): UserRecord;
+    public function createUserWithEmailAndPassword(string $email, string $password): UserRecord;
 
     /**
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      *
      * @throws UserNotFound
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function getUserByEmail(Stringable|string $email): UserRecord;
+    public function getUserByEmail(string $email): UserRecord;
 
     /**
-     * @param Stringable|non-empty-string $phoneNumber
+     * @param non-empty-string $phoneNumber
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function getUserByPhoneNumber(Stringable|string $phoneNumber): UserRecord;
+    public function getUserByPhoneNumber(string $phoneNumber): UserRecord;
 
     /**
      * @throws Exception\AuthException
@@ -131,50 +131,50 @@ interface Auth
     public function createAnonymousUser(): UserRecord;
 
     /**
-     * @param Stringable|non-empty-string $uid
-     * @param Stringable|non-empty-string $newPassword
+     * @param non-empty-string $uid
+     * @param non-empty-string $newPassword
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function changeUserPassword(Stringable|string $uid, Stringable|string $newPassword): UserRecord;
+    public function changeUserPassword(string $uid, string $newPassword): UserRecord;
 
     /**
-     * @param Stringable|non-empty-string $uid
-     * @param Stringable|non-empty-string $newEmail
+     * @param non-empty-string $uid
+     * @param non-empty-string $newEmail
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function changeUserEmail(Stringable|string $uid, Stringable|string $newEmail): UserRecord;
+    public function changeUserEmail(string $uid, string $newEmail): UserRecord;
 
     /**
-     * @param Stringable|non-empty-string $uid
+     * @param non-empty-string $uid
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function enableUser(Stringable|string $uid): UserRecord;
+    public function enableUser(string $uid): UserRecord;
 
     /**
-     * @param Stringable|non-empty-string $uid
+     * @param non-empty-string $uid
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function disableUser(Stringable|string $uid): UserRecord;
+    public function disableUser(string $uid): UserRecord;
 
     /**
-     * @param Stringable|non-empty-string $uid
+     * @param non-empty-string $uid
      *
      * @throws UserNotFound
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function deleteUser(Stringable|string $uid): void;
+    public function deleteUser(string $uid): void;
 
     /**
-     * @param iterable<Stringable|non-empty-string> $uids
+     * @param iterable<non-empty-string> $uids
      * @param bool $forceDeleteEnabledUsers Whether to force deleting accounts that are not in disabled state. If false, only disabled accounts will be deleted, and accounts that are not disabled will be added to the errors.
      *
      * @throws Exception\AuthException
@@ -183,91 +183,91 @@ interface Auth
 
     /**
      * @param non-empty-string $type
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param ActionCodeSettings|array<non-empty-string, mixed>|null $actionCodeSettings
      * @param non-empty-string|null $locale
      *
      * @throws FailedToCreateActionLink
      */
-    public function getEmailActionLink(string $type, Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): string;
+    public function getEmailActionLink(string $type, string $email, $actionCodeSettings = null, ?string $locale = null): string;
 
     /**
      * @param non-empty-string $type
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param ActionCodeSettings|array<non-empty-string, mixed>|null $actionCodeSettings
      * @param non-empty-string|null $locale
      *
      * @throws UserNotFound
      * @throws FailedToSendActionLink
      */
-    public function sendEmailActionLink(string $type, Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): void;
+    public function sendEmailActionLink(string $type, string $email, $actionCodeSettings = null, ?string $locale = null): void;
 
     /**
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param ActionCodeSettings|array<non-empty-string, mixed>|null $actionCodeSettings
      * @param non-empty-string|null $locale
      *
      * @throws FailedToCreateActionLink
      */
-    public function getEmailVerificationLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): string;
+    public function getEmailVerificationLink(string $email, $actionCodeSettings = null, ?string $locale = null): string;
 
     /**
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param ActionCodeSettings|array<non-empty-string, mixed>|null $actionCodeSettings
      * @param non-empty-string|null $locale
      *
      * @throws FailedToSendActionLink
      */
-    public function sendEmailVerificationLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): void;
+    public function sendEmailVerificationLink(string $email, $actionCodeSettings = null, ?string $locale = null): void;
 
     /**
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param ActionCodeSettings|array<non-empty-string, mixed>|null $actionCodeSettings
      * @param non-empty-string|null $locale
      *
      * @throws FailedToCreateActionLink
      */
-    public function getPasswordResetLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): string;
+    public function getPasswordResetLink(string $email, $actionCodeSettings = null, ?string $locale = null): string;
 
     /**
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param ActionCodeSettings|array<non-empty-string, mixed>|null $actionCodeSettings
      * @param non-empty-string|null $locale
      *
      * @throws FailedToSendActionLink
      */
-    public function sendPasswordResetLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): void;
+    public function sendPasswordResetLink(string $email, $actionCodeSettings = null, ?string $locale = null): void;
 
     /**
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param ActionCodeSettings|array<non-empty-string, mixed>|null $actionCodeSettings
      * @param non-empty-string|null $locale
      *
      * @throws FailedToCreateActionLink
      */
-    public function getSignInWithEmailLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): string;
+    public function getSignInWithEmailLink(string $email, $actionCodeSettings = null, ?string $locale = null): string;
 
     /**
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param ActionCodeSettings|array<non-empty-string, mixed>|null $actionCodeSettings
      * @param non-empty-string|null $locale
      *
      * @throws FailedToSendActionLink
      */
-    public function sendSignInWithEmailLink(Stringable|string $email, $actionCodeSettings = null, ?string $locale = null): void;
+    public function sendSignInWithEmailLink(string $email, $actionCodeSettings = null, ?string $locale = null): void;
 
     /**
      * Sets additional developer claims on an existing user identified by the provided UID.
      *
      * @see https://firebase.google.com/docs/auth/admin/custom-claims
      *
-     * @param Stringable|non-empty-string $uid
+     * @param non-empty-string $uid
      * @param array<non-empty-string, mixed>|null $claims
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function setCustomUserClaims(Stringable|string $uid, ?array $claims): void;
+    public function setCustomUserClaims(string $uid, ?array $claims): void;
 
     /**
      * @param array<non-empty-string, mixed> $claims
@@ -276,7 +276,7 @@ interface Auth
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function createCustomToken(Stringable|string $uid, array $claims = [], int|DateInterval|string $ttl = 3600): UnencryptedToken;
+    public function createCustomToken(string $uid, array $claims = [], int|DateInterval|string $ttl = 3600): UnencryptedToken;
 
     /**
      * @param non-empty-string $tokenString
@@ -359,7 +359,7 @@ interface Auth
      * @see https://firebase.google.com/docs/reference/rest/auth#section-confirm-reset-password
      *
      * @param non-empty-string $oobCode the email action code sent to the user's email for resetting the password
-     * @param Stringable|non-empty-string $newPassword
+     * @param non-empty-string $newPassword
      * @param bool $invalidatePreviousSessions Invalidate sessions initialized with the previous credentials
      *
      * @throws ExpiredOobCode
@@ -369,7 +369,7 @@ interface Auth
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function confirmPasswordReset(string $oobCode, Stringable|string $newPassword, bool $invalidatePreviousSessions = true): string;
+    public function confirmPasswordReset(string $oobCode, string $newPassword, bool $invalidatePreviousSessions = true): string;
 
     /**
      * Revokes all refresh tokens for the specified user identified by the uid provided.
@@ -377,29 +377,29 @@ interface Auth
      * before revocation will also be revoked on the Auth backend. Any request with an
      * ID token generated before revocation will be rejected with a token expired error.
      *
-     * @param Stringable|string $uid the user whose tokens are to be revoked
+     * @param string $uid the user whose tokens are to be revoked
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function revokeRefreshTokens(Stringable|string $uid): void;
+    public function revokeRefreshTokens(string $uid): void;
 
     /**
-     * @param Stringable|non-empty-string $uid
-     * @param list<Stringable|non-empty-string>|Stringable|non-empty-string $provider
+     * @param non-empty-string $uid
+     * @param list<non-empty-string>|non-empty-string $provider
      *
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function unlinkProvider(Stringable|string $uid, array|Stringable|string $provider): UserRecord;
+    public function unlinkProvider(string $uid, array|string $provider): UserRecord;
 
     /**
-     * @param UserRecord|Stringable|non-empty-string $user
+     * @param UserRecord|non-empty-string $user
      * @param array<non-empty-string, mixed>|null $claims
      *
      * @throws FailedToSignIn
      */
-    public function signInAsUser(UserRecord|Stringable|string $user, ?array $claims = null): SignInResult;
+    public function signInAsUser(UserRecord|string $user, ?array $claims = null): SignInResult;
 
     /**
      * @param Token|non-empty-string $token
@@ -416,20 +416,20 @@ interface Auth
     public function signInWithRefreshToken(string $refreshToken): SignInResult;
 
     /**
-     * @param Stringable|non-empty-string $email
-     * @param Stringable|non-empty-string $clearTextPassword
+     * @param non-empty-string $email
+     * @param non-empty-string $clearTextPassword
      *
      * @throws FailedToSignIn
      */
-    public function signInWithEmailAndPassword(Stringable|string $email, Stringable|string $clearTextPassword): SignInResult;
+    public function signInWithEmailAndPassword(string $email, string $clearTextPassword): SignInResult;
 
     /**
-     * @param Stringable|non-empty-string $email
+     * @param non-empty-string $email
      * @param non-empty-string $oobCode
      *
      * @throws FailedToSignIn
      */
-    public function signInWithEmailAndOobCode(Stringable|string $email, string $oobCode): SignInResult;
+    public function signInWithEmailAndOobCode(string $email, string $oobCode): SignInResult;
 
     /**
      * @throws FailedToSignIn
@@ -439,7 +439,7 @@ interface Auth
     /**
      * @see https://cloud.google.com/identity-platform/docs/reference/rest/v1/accounts/signInWithIdp
      *
-     * @param Stringable|non-empty-string $provider
+     * @param non-empty-string $provider
      * @param non-empty-string $accessToken
      * @param UriInterface|non-empty-string|null $redirectUrl
      * @param non-empty-string|null $oauthTokenSecret
@@ -448,10 +448,10 @@ interface Auth
      *
      * @throws FailedToSignIn
      */
-    public function signInWithIdpAccessToken(Stringable|string $provider, string $accessToken, $redirectUrl = null, ?string $oauthTokenSecret = null, ?string $linkingIdToken = null, ?string $rawNonce = null): SignInResult;
+    public function signInWithIdpAccessToken(string $provider, string $accessToken, $redirectUrl = null, ?string $oauthTokenSecret = null, ?string $linkingIdToken = null, ?string $rawNonce = null): SignInResult;
 
     /**
-     * @param Stringable|non-empty-string $provider
+     * @param non-empty-string $provider
      * @param Token|non-empty-string $idToken
      * @param UriInterface|non-empty-string|null $redirectUrl
      * @param non-empty-string|null $linkingIdToken
@@ -459,5 +459,5 @@ interface Auth
      *
      * @throws FailedToSignIn
      */
-    public function signInWithIdpIdToken(Stringable|string $provider, Token|string $idToken, $redirectUrl = null, ?string $linkingIdToken = null, ?string $rawNonce = null): SignInResult;
+    public function signInWithIdpIdToken(string $provider, Token|string $idToken, $redirectUrl = null, ?string $linkingIdToken = null, ?string $rawNonce = null): SignInResult;
 }

--- a/src/Firebase/Contract/Transitional/FederatedUserFetcher.php
+++ b/src/Firebase/Contract/Transitional/FederatedUserFetcher.php
@@ -7,7 +7,6 @@ namespace Kreait\Firebase\Contract\Transitional;
 use Kreait\Firebase\Auth\UserRecord;
 use Kreait\Firebase\Exception;
 use Kreait\Firebase\Exception\Auth\UserNotFound;
-use Stringable;
 
 /**
  * @TODO: This interface is intended to be integrated into the Auth interface on the next major release.
@@ -15,12 +14,12 @@ use Stringable;
 interface FederatedUserFetcher
 {
     /**
-     * @param Stringable|non-empty-string $providerId
-     * @param Stringable|non-empty-string $providerUid
+     * @param non-empty-string $providerId
+     * @param non-empty-string $providerUid
      *
      * @throws UserNotFound
      * @throws Exception\AuthException
      * @throws Exception\FirebaseException
      */
-    public function getUserByProviderUid(Stringable|string $providerId, Stringable|string $providerUid): UserRecord;
+    public function getUserByProviderUid(string $providerId, string $providerUid): UserRecord;
 }

--- a/src/Firebase/Messaging/CloudMessage.php
+++ b/src/Firebase/Messaging/CloudMessage.php
@@ -7,7 +7,6 @@ namespace Kreait\Firebase\Messaging;
 use Beste\Json;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Exception\Messaging\InvalidArgument;
-use Stringable;
 
 use function array_filter;
 use function array_intersect;
@@ -104,7 +103,7 @@ final class CloudMessage implements Message
     }
 
     /**
-     * @param MessageData|array<non-empty-string, Stringable|string> $data
+     * @param MessageData|array<non-empty-string, string> $data
      *
      * @throws InvalidArgumentException
      */

--- a/src/Firebase/Messaging/Message.php
+++ b/src/Firebase/Messaging/Message.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Messaging;
 
 use JsonSerializable;
-use Stringable;
 
 /**
  * @phpstan-import-type AndroidConfigShape from AndroidConfig
@@ -18,7 +17,7 @@ use Stringable;
  *     token?: non-empty-string,
  *     topic?: non-empty-string,
  *     condition?: non-empty-string,
- *     data?: MessageData|array<non-empty-string, Stringable|string>,
+ *     data?: MessageData|array<non-empty-string, string>,
  *     notification?: Notification|NotificationShape,
  *     android?: AndroidConfigShape,
  *     apns?: ApnsConfig|ApnsConfigShape,

--- a/src/Firebase/Messaging/MessageData.php
+++ b/src/Firebase/Messaging/MessageData.php
@@ -6,7 +6,6 @@ namespace Kreait\Firebase\Messaging;
 
 use JsonSerializable;
 use Kreait\Firebase\Exception\InvalidArgumentException;
-use Stringable;
 
 use function in_array;
 use function mb_detect_encoding;
@@ -24,15 +23,13 @@ final readonly class MessageData implements JsonSerializable
     }
 
     /**
-     * @param array<non-empty-string, Stringable|string> $data
+     * @param array<non-empty-string, string> $data
      */
     public static function fromArray(array $data): self
     {
         $validated = [];
 
         foreach ($data as $key => $value) {
-            $value = (string) $value;
-
             if (self::isBinary($value)) {
                 throw new InvalidArgumentException(
                     "The message data field '{$key}' seems to contain binary data. As this can lead to broken messages, "

--- a/src/Firebase/Request/EditUserTrait.php
+++ b/src/Firebase/Request/EditUserTrait.php
@@ -9,7 +9,6 @@ use Kreait\Firebase\Value\ClearTextPassword;
 use Kreait\Firebase\Value\Email;
 use Kreait\Firebase\Value\Uid;
 use Kreait\Firebase\Value\Url;
-use Stringable;
 
 use function array_filter;
 use function mb_strtolower;
@@ -41,7 +40,7 @@ trait EditUserTrait
     /** @var array<string, mixed>|null */
     protected ?array $multiFactor = null;
 
-    public function withUid(Stringable|string $uid): self
+    public function withUid(string $uid): self
     {
         $request = clone $this;
         $request->uid = Uid::fromString($uid)->value;
@@ -49,27 +48,27 @@ trait EditUserTrait
         return $request;
     }
 
-    public function withEmail(Stringable|string $email): self
+    public function withEmail(string $email): self
     {
         $request = clone $this;
-        $request->email = Email::fromString((string) $email)->value;
+        $request->email = Email::fromString($email)->value;
 
         return $request;
     }
 
-    public function withVerifiedEmail(Stringable|string $email): self
+    public function withVerifiedEmail(string $email): self
     {
         $request = clone $this;
-        $request->email = Email::fromString((string) $email)->value;
+        $request->email = Email::fromString($email)->value;
         $request->emailIsVerified = true;
 
         return $request;
     }
 
-    public function withUnverifiedEmail(Stringable|string $email): self
+    public function withUnverifiedEmail(string $email): self
     {
         $request = clone $this;
-        $request->email = Email::fromString((string) $email)->value;
+        $request->email = Email::fromString($email)->value;
         $request->emailIsVerified = false;
 
         return $request;
@@ -84,19 +83,17 @@ trait EditUserTrait
     }
 
     /**
-     * @param Stringable|string|null $phoneNumber
+     * @param non-empty-string|null $phoneNumber
      */
-    public function withPhoneNumber($phoneNumber): self
+    public function withPhoneNumber(string|null $phoneNumber): self
     {
-        $phoneNumber = $phoneNumber !== null ? (string) $phoneNumber : null;
-
         $request = clone $this;
         $request->phoneNumber = $phoneNumber;
 
         return $request;
     }
 
-    public function withPhotoUrl(Stringable|string $url): self
+    public function withPhotoUrl(string $url): self
     {
         $request = clone $this;
         $request->photoUrl = Url::fromString($url)->value;
@@ -138,7 +135,7 @@ trait EditUserTrait
         return $request;
     }
 
-    public function withClearTextPassword(Stringable|string $clearTextPassword): self
+    public function withClearTextPassword(string $clearTextPassword): self
     {
         $request = clone $this;
         $request->clearTextPassword = ClearTextPassword::fromString($clearTextPassword)->value;

--- a/src/Firebase/Request/UpdateUser.php
+++ b/src/Firebase/Request/UpdateUser.php
@@ -7,9 +7,6 @@ namespace Kreait\Firebase\Request;
 use Beste\Json;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Request;
-use Stringable;
-
-use function array_reduce;
 use function array_unique;
 use function is_array;
 use function is_string;
@@ -146,11 +143,13 @@ final class UpdateUser implements Request
                 case 'deleteproviders':
                 case 'removeprovider':
                 case 'removeproviders':
-                    $request = array_reduce(
-                        (array) $value,
-                        static fn(self $request, $provider): UpdateUser => $request->withRemovedProvider($provider),
-                        $request,
-                    );
+                    if (is_string($value)) {
+                        $value = [$value];
+                    }
+
+                    foreach ($value as $provider) {
+                        $request = $request->withRemovedProvider($provider);
+                    }
 
                     break;
 
@@ -180,18 +179,12 @@ final class UpdateUser implements Request
     }
 
     /**
-     * @param Stringable|string $provider
+     * @param non-empty-string $provider
      */
-    public function withRemovedProvider($provider): self
+    public function withRemovedProvider(string $provider): self
     {
-        $providerString = trim((string) $provider);
-
-        if ($providerString === '') {
-            return $this;
-        }
-
         $request = clone $this;
-        $request->providersToDelete[] = $providerString;
+        $request->providersToDelete[] = $provider;
 
         return $request;
     }

--- a/src/Firebase/Value/ClearTextPassword.php
+++ b/src/Firebase/Value/ClearTextPassword.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Value;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
-use Stringable;
 
 use function mb_strlen;
 
@@ -28,8 +27,8 @@ final readonly class ClearTextPassword
         $this->value = $value;
     }
 
-    public static function fromString(Stringable|string $value): self
+    public static function fromString(string $value): self
     {
-        return new self((string) $value);
+        return new self($value);
     }
 }

--- a/src/Firebase/Value/Email.php
+++ b/src/Firebase/Value/Email.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Value;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
-use Stringable;
 
 use function filter_var;
 
@@ -30,8 +29,8 @@ final readonly class Email
         $this->value = $value;
     }
 
-    public static function fromString(Stringable|string $value): self
+    public static function fromString(string $value): self
     {
-        return new self((string) $value);
+        return new self($value);
     }
 }

--- a/src/Firebase/Value/Uid.php
+++ b/src/Firebase/Value/Uid.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Value;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
-use Stringable;
 
 use function mb_strlen;
 
@@ -28,8 +27,8 @@ final readonly class Uid
         $this->value = $value;
     }
 
-    public static function fromString(Stringable|string $value): self
+    public static function fromString(string $value): self
     {
-        return new self((string) $value);
+        return new self($value);
     }
 }

--- a/src/Firebase/Value/Url.php
+++ b/src/Firebase/Value/Url.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kreait\Firebase\Value;
 
 use Kreait\Firebase\Exception\InvalidArgumentException;
-use Stringable;
 
 /**
  * @internal
@@ -32,10 +31,8 @@ final readonly class Url
         $this->value = $value;
     }
 
-    public static function fromString(Stringable|string $value): self
+    public static function fromString(string $value): self
     {
-        $value = (string) $value;
-
         if ($value === '') {
             throw new InvalidArgumentException('The URL cannot be empty.');
         }

--- a/tests/Unit/Messaging/MessageDataTest.php
+++ b/tests/Unit/Messaging/MessageDataTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Stringable;
 
 use function hex2bin;
 
@@ -21,7 +20,7 @@ use function hex2bin;
 final class MessageDataTest extends TestCase
 {
     /**
-     * @param array<non-empty-string, Stringable|string> $data
+     * @param array<non-empty-string, string> $data
      */
     #[DoesNotPerformAssertions]
     #[DataProvider('validData')]
@@ -32,7 +31,7 @@ final class MessageDataTest extends TestCase
     }
 
     /**
-     * @param array<non-empty-string, Stringable|string> $data
+     * @param array<non-empty-string, string> $data
      */
     #[DataProvider('invalidData')]
     #[Test]
@@ -57,29 +56,6 @@ final class MessageDataTest extends TestCase
 
     public static function validData(): Iterator
     {
-        yield 'integer' => [
-            ['key' => 1],
-        ];
-        yield 'float' => [
-            ['key' => 1.23],
-        ];
-        yield 'true' => [
-            ['key' => true],
-        ];
-        yield 'false' => [
-            ['key' => false],
-        ];
-        yield 'null' => [
-            ['key' => null],
-        ];
-        yield 'object with __toString()' => [
-            ['key' => new class {
-                public function __toString(): string
-                {
-                    return 'value';
-                }
-            }],
-        ];
         yield 'UTF-8 string' => [
             ['key' => 'Jérôme'],
         ];

--- a/tests/Unit/Value/UrlTest.php
+++ b/tests/Unit/Value/UrlTest.php
@@ -10,7 +10,6 @@ use Kreait\Firebase\Value\Url;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Stringable;
 
 /**
  * @internal
@@ -19,11 +18,11 @@ final class UrlTest extends TestCase
 {
     #[DataProvider('validValues')]
     #[Test]
-    public function withValidValue(Stringable|string $value): void
+    public function withValidValue(string $value): void
     {
         $url = Url::fromString($value)->value;
 
-        $check = (string) $value;
+        $check = $value;
 
         $this->assertSame($check, $url);
     }


### PR DESCRIPTION
Methods that previously accepted `Stringable|string` as argument types now only support `string`.

`Stringable` was added for convenience so that someone could do, for example

```php
$user = $auth->getUser('uid');
$auth->updateUser($user, [...]);
```

While convenient, this adds overhead when processing these arguments. For example, if a method expects a non-empty string, the SDK would have to do a `trim((string) $arg)` and check if it's empty.

With this change, we can rely only on a `@var non-empty-string $arg` docblock annotation.

```php
$user = $auth->getUser('uid');
$auth->updateUser($user->uid, [...]);
```