### PR TITLE
Isolate grpc tests

### DIFF
--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -32,9 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      php-version: '8.4'
-      extensions: grpc
-      key: cache-v1
+      php-version: '8.5'
 
     steps:
       - name: Checkout code
@@ -42,26 +40,10 @@ jobs:
         with:
           ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.sha) || github.sha }}
 
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
-        with:
-          php-version: ${{ env.php-version }}
-          extensions: ${{ env.extensions }}
-          key: ${{ env.key }}
-
-      - name: Cache extensions
-        uses: actions/cache@v5.0.3
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ env.php-version }}
-          extensions: ${{ env.extensions }}
           tools: composer, pecl
           coverage: xdebug
 
@@ -69,6 +51,8 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
       - uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--ignore-platform-req=ext-grpc"
 
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -97,7 +81,7 @@ jobs:
           FIREBASE_DATABASE_EMULATOR_HOST: localhost:9100
           FIREBASE_AUTH_EMULATOR_HOST: localhost:9099
           XDEBUG_MODE: coverage
-        run: firebase emulators:exec --only auth,database --project beste-firebase 'XDEBUG_MODE=coverage vendor/bin/phpunit --group=emulator --coverage-clover=coverage.xml --log-junit=test-report.xml'
+        run: firebase emulators:exec --only auth,database --project beste-firebase 'XDEBUG_MODE=coverage vendor/bin/phpunit --group=emulator --exclude-group grpc --coverage-clover=coverage.xml --log-junit=test-report.xml'
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/grpc-tests.yml
+++ b/.github/workflows/grpc-tests.yml
@@ -1,0 +1,127 @@
+name: gRPC Tests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/grpc-tests.yml'
+      - 'composer.json'
+      - 'phpstan.neon.dist'
+  push:
+    branches: ['8.x']
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/grpc-tests.yml'
+      - 'composer.json'
+      - 'phpstan.neon.dist'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  grpc-tests:
+    name: gRPC Tests (PHP 8.5)
+    runs-on: ubuntu-latest
+    # Non-blocking while the gRPC extension is broken/unstable on PHP 8.5.
+    # See https://github.com/shivammathur/setup-php/issues/1041.
+    # Remove this once upstream releases a stable extension and tests pass.
+    continue-on-error: true
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+    env:
+      key: cache-grpc
+      php-version: 8.5
+      extensions: grpc
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.sha) || github.sha }}
+
+      - name: Setup cache environment
+        id: extcache
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: ${{ env.php-version }}
+          extensions: ${{ env.extensions }}
+          key: ${{ env.key }}
+
+      - name: Cache extensions
+        uses: actions/cache@v5.0.2
+        with:
+          path: ${{ steps.extcache.outputs.dir }}
+          key: ${{ steps.extcache.outputs.key }}
+          restore-keys: ${{ steps.extcache.outputs.key }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.php-version }}
+          extensions: ${{ env.extensions }}
+          ini-values: grpc.grpc_verbosity=error, grpc.grpc_trace=
+          tools: composer, pecl
+          coverage: xdebug
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Verify gRPC extension
+        id: grpc
+        run: php -m | grep -i '^grpc$'
+
+      - uses: "ramsey/composer-install@v3"
+        id: composer
+        if: ${{ steps.grpc.outcome == 'success' }}
+
+      - name: Setup Problem Matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Run gRPC Tests
+        id: grpc-tests
+        if: ${{ steps.grpc.outcome == 'success' }}
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+          TEST_FIREBASE_APP_ID: ${{secrets.TEST_FIREBASE_APP_ID}}
+          TEST_FIREBASE_RTDB_URI: ${{secrets.TEST_FIREBASE_RTDB_URI}}
+          TEST_FIREBASE_TENANT_ID: ${{secrets.TEST_FIREBASE_TENANT_ID}}
+          TEST_REGISTRATION_TOKENS: ${{secrets.TEST_REGISTRATION_TOKENS}}
+          XDEBUG_MODE: coverage
+        run: vendor/bin/phpunit --testsuite=integration --group grpc --coverage-clover=coverage.xml --log-junit=test-report.xml --testdox
+
+      - name: Summarize gRPC failures
+        if: ${{ always() && (steps.grpc.outcome == 'failure' || steps.grpc-tests.outcome == 'failure') }}
+        run: |
+          echo "::notice::gRPC tests are non-blocking due to missing/broken gRPC on PHP 8.5."
+          {
+            echo "### gRPC tests are non-blocking"
+            echo
+            echo "gRPC extension was not available or gRPC tests failed (likely due to missing/broken gRPC on PHP 8.5)."
+            echo "See https://github.com/shivammathur/setup-php/issues/1041."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && steps.grpc.outcome == 'success' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: grpc
+          report_type: test_results
+          fail_ci_if_error: false
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() && steps.grpc.outcome == 'success' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: grpc
+          fail_ci_if_error: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,9 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      php-version: '8.4'
-      extensions: grpc
-      key: cache-v1
+      php-version: '8.5'
 
     steps:
       - name: Checkout code
@@ -42,26 +40,10 @@ jobs:
         with:
           ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.sha) || github.sha }}
 
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
-        with:
-          php-version: ${{ env.php-version }}
-          extensions: ${{ env.extensions }}
-          key: ${{ env.key }}
-
-      - name: Cache extensions
-        uses: actions/cache@v5.0.3
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ env.php-version }}
-          extensions: ${{ env.extensions }}
           tools: composer, pecl
           coverage: xdebug
 
@@ -69,6 +51,8 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
       - uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--ignore-platform-req=ext-grpc"
 
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -81,7 +65,7 @@ jobs:
           TEST_FIREBASE_TENANT_ID: ${{secrets.TEST_FIREBASE_TENANT_ID}}
           TEST_REGISTRATION_TOKENS: ${{secrets.TEST_REGISTRATION_TOKENS}}
           XDEBUG_MODE: coverage
-        run: vendor/bin/phpunit --testsuite=integration --coverage-clover=coverage.xml --log-junit=test-report.xml --testdox
+        run: vendor/bin/phpunit --testsuite=integration --exclude-group grpc --coverage-clover=coverage.xml --log-junit=test-report.xml --testdox
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -38,40 +38,20 @@ jobs:
           - "8.4"
           - "8.5"
 
-    env:
-      extensions: grpc
-      key: cache-v1
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
-          key: ${{ env.key }}
-
-      - name: Cache extensions
-        uses: actions/cache@v5.0.3
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
           tools: composer, pecl
           coverage: none
 
       - uses: "ramsey/composer-install@v3"
         with:
-          composer-options: "${{ matrix.composer-options }}"
+          composer-options: "--ignore-platform-req=ext-grpc"
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,40 +41,20 @@ jobs:
           - "lowest"
           - "highest"
 
-    env:
-      extensions: grpc
-      key: cache-v1
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
-          key: ${{ env.key }}
-
-      - name: Cache extensions
-        uses: actions/cache@v5.0.3
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
           tools: composer, pecl
           coverage: xdebug
 
       - uses: "ramsey/composer-install@v3"
         with:
-          composer-options: "${{ matrix.composer-options }}"
+          composer-options: "--ignore-platform-req=ext-grpc"
           dependency-versions: "${{ matrix.dependencies }}"
 
       - name: Setup problem matchers for PHP

--- a/tests/Integration/Factory/FirestoreTest.php
+++ b/tests/Integration/Factory/FirestoreTest.php
@@ -7,10 +7,14 @@ namespace Kreait\Firebase\Tests\Integration\Factory;
 use Exception;
 use Kreait\Firebase\Tests\IntegrationTestCase;
 use Kreait\Firebase\Util;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * @internal
  */
+#[Group('grpc')]
+#[RequiresPhpExtension('grpc')]
 final class FirestoreTest extends IntegrationTestCase
 {
     /**
@@ -19,11 +23,6 @@ final class FirestoreTest extends IntegrationTestCase
      */
     public function testItUsesTheDefaultDatabaseByDefault(): void
     {
-        // @see https://github.com/grpc/grpc/issues/38184
-        // @see https://github.com/googleapis/gax-php/issues/584
-        // @see https://www.php.net/manual/en/info.configuration.php#ini.zend.reserved-stack-size
-        $this->markTestSkipped('Skipped because of an infinite recursion with certain PHP/gRPC versions.');
-        // @phpstan-ignore deadCode.unreachable
         $collection = __FUNCTION__;
         $documentName = __FUNCTION__.self::randomString();
 
@@ -42,11 +41,6 @@ final class FirestoreTest extends IntegrationTestCase
 
     public function testItCannotConnectToAnUnknownDatabase(): void
     {
-        // @see https://github.com/grpc/grpc/issues/38184
-        // @see https://github.com/googleapis/gax-php/issues/584
-        // @see https://www.php.net/manual/en/info.configuration.php#ini.zend.reserved-stack-size
-        $this->markTestSkipped('Skipped because of an infinite recursion with certain PHP/gRPC versions.');
-        // @phpstan-ignore deadCode.unreachable
         $name = self::randomString();
 
         $database = self::$factory->createFirestore($name)->database();


### PR DESCRIPTION
- mark Firestore integration tests as `grpc` and `RequiresExtension('grpc')`
- exclude gRPC group from existing test workflows and ignore `ext-grpc` platform req
- add dedicated gRPC workflow (PHP 8.4) with coverage + Codecov `grpc` flag
- set gRPC ini verbosity in CI to suppress noisy logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * gRPC integration tests are now grouped and require gRPC; previously skipped tests are re-enabled. CI excludes gRPC tests by default and a dedicated gRPC test workflow runs them when available.
* **Chores**
  * Simplified CI by removing per-job extension caching, made install steps tolerant of a missing gRPC extension, and upgraded CI PHP runtime to 8.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->