### PR TITLE
Update firebase/php-jwt version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Please update your remote URL if you have forked or cloned the repository.
 ## Unreleased
 
 * Added support for `guzzlehttp/guzzle:^8.0`, `guzzlehttp/psr7:^3.0` and `guzzlehttp/promises:^3.0`.
+* Updated the `firebase/php-jwt` constraint to `^7.0.2`. Although
+  [CVE-2025-45769](https://github.com/advisories/GHSA-2x45-7fc3-mxwq) is rated as low severity, it has been
+  [disputed](https://github.com/googleapis/php-jwt/issues/620) on the basis that applications, rather than
+  the library, are responsible for choosing appropriate key lengths. Nevertheless, a review of the library's
+  [most-downloaded dependents](https://packagist.org/packages/firebase/php-jwt/dependents?order_by=downloads)
+  showed that most already support version 7.x.
 
 ## 8.3.0 - 2026-07-18
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "beste/json": "^1.5.1",
         "cuyz/valinor": "^2.2.1",
         "fig/http-message-util": "^1.1.5",
-        "firebase/php-jwt": "^6.10.2 || ^7.0.2",
+        "firebase/php-jwt": "^7.0.2",
         "google/auth": "^1.45",
         "google/cloud-storage": "^1.50.0 || ^2.0.0",
         "guzzlehttp/guzzle": "^7.9.2 || ^8.0",


### PR DESCRIPTION
Updated firebase/php-jwt version constraint to only allow 7.0.2 or higher. This addresses the security advisory on versions less than 7 

https://github.com/advisories/GHSA-2x45-7fc3-mxwq